### PR TITLE
docs: README for the digitized Jachertz 1983 thesis (state, comparison, timeline)

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -1,19 +1,26 @@
-# Project Objective: [Global Goal]
-
-<!-- Replace the bracket above with the current high-level goal for this session. -->
+# Project Objective: Conservative Cologne issue batch triage for PWK markup/question candidates
 
 ## ➡️ Next Steps (Queue)
 
-- [ ] (none queued yet)
+- [ ] If a maintainer wants display work for PWK #66, verify whether the live CDSL display resolves `<ab>s. u.</ab>` cross-references as links; route as DTB/linking work, not a source-text correction.
+- [ ] If revisiting PWK #58, inspect each live `<sic/>` marker semantically before patching; the current evidence supports review-only status, not a mechanical markup replacement.
+- [ ] For a future markup batch, prefer a candidate with an exact active bad pattern in `csl-orig/v02/pw/pw.txt` and a documented `updateByLine.py` change file.
 
 ## 🚧 Current Work-In-Progress (WIP)
 
-- [ ] (no active task)
+- [ ] No active source edit. 2026-06-27 triage found no PWK markup candidate that passed the safe-edit gates.
 
-## 🧠 Dev Notes & Hypotheses
+## 🧠 Dev Notes & Hypotheses (Bugs, ideas, context)
 
-<!-- Persistent bugs, architectural pivots, things future-you needs to know. Keep dated. -->
+- 2026-06-27 Cologne batch candidate matrix:
+  - PWK #58 "Cases of |<sic>": `markup`, `minor`, but the issue asks for examination rather than a replacement rule. Current canonical `csl-orig/v02/pw/pw.txt` has 27 self-closing `<sic/>` markers; no exact safe normalization was identified. Decision: `needs-human-review` / review-only.
+  - PWK #66 "•»s.u. markup question": `question`, `minor`. Evidence from the issue thread and local PWK abbreviation work shows `s.u.` = Latin *sub voce* ("see under") and current markup normalizes it as `<ab>s. u.</ab>` / `<ab>s.u.</ab>` in prior issue work. Decision: `answer-only` unless display/link behavior is currently wrong.
+  - PWK markup-fix audit singleton candidates (`{%des%}<is>Agni</is>` and `</ls>.[Page...]`) are stale in current `csl-orig/v02/pw/pw.txt`; both boundaries already contain the missing spaces.
+  - MWS markup candidates were not promoted in this batch because the local worktree contains unrelated untracked preface/scans output and the sampled issue (#178) points back to a discussion thread rather than an exact local source replacement.
+  - csl-orig text-correction candidate #1537 was not promoted because the live issue fetch was intermittent and no exact old/new line-level change was established during triage.
+  - AP90/VCP/SKD/PWG csl-orig pattern scan for the PW/PWG audit patterns found no one-line safe equivalent; PWG hits are mostly legitimate compounds like `{%Musik-%}<is>Veda</is>`, not missing-space bugs.
 
 ## ✅ Completed (Recent only)
 
-<!-- Move items here as they're checked off. Trim aggressively — only the recent few. -->
+- [x] 2026-06-27: Ran first conservative Cologne issue-batch triage across PWK/MWS/AP90/PWG/SKD/VCP/csl-orig lanes; no source edits made because no candidate passed all safety gates.
+- [x] 2026-06-27: Classified PWK #66 as `answer-only`: `s.u.` is a sub-voce cross-reference convention; next work, if any, belongs to display/link verification.

--- a/.ai_state.md
+++ b/.ai_state.md
@@ -4,6 +4,8 @@
 
 - [ ] If a maintainer wants display work for PWK #66, verify whether the live CDSL display resolves `<ab>s. u.</ab>` cross-references as links; route as DTB/linking work, not a source-text correction.
 - [ ] If revisiting PWK #58, inspect each live `<sic/>` marker semantically before patching; the current evidence supports review-only status, not a mechanical markup replacement.
+- [ ] If revisiting PWK #67, use issue88 abbreviation-markup outputs as the baseline; current `pw.txt` already marks `Simpl.` as `<ab>Simpl.</ab>`, so look for a different active abbreviation gap before proposing source edits.
+- [ ] Treat PWK #15 and #65 as question/human-review bibliography cases unless a maintainer supplies exact link-resolution or abbreviation-merging rules.
 - [ ] For a future markup batch, prefer a candidate with an exact active bad pattern in `csl-orig/v02/pw/pw.txt` and a documented `updateByLine.py` change file.
 
 ## 🚧 Current Work-In-Progress (WIP)
@@ -13,8 +15,12 @@
 ## 🧠 Dev Notes & Hypotheses (Bugs, ideas, context)
 
 - 2026-06-27 Cologne batch candidate matrix:
+  - PWK #12 "Abbreviations bracket not proper": `bug`, `minor`. Issue body cites the historical regex `<ls>\(([^)]+)</ls>\)` and a 304-hit `pw.xml` report. Current workspace lacks `pwxml`/`pwkxml`, but canonical `csl-orig/v02/pw/pw.txt` has no active `rg "<ls>\([^)]*</ls>\)"` hits; the nearest `<ls>(MĀN.) GṚHY...` cases keep the parentheses inside `<ls>` and are valid. Decision: stale/no-op until an active source file reproduces the exact bad pattern.
+  - PWK #15 "Duplicate abbreviations in pwbib1": `markup`, `minor`. Issue comments enumerate volume-dependent duplicate bibliography abbreviations and explicitly note future link-resolution concerns. Local `pw_ls/pwbib/crefmatch_log.txt` still reports duplicate abbreviations, but no single old/new source rule is present. Decision: `needs-human-review`; do not patch `pwbib1.txt` mechanically.
   - PWK #58 "Cases of |<sic>": `markup`, `minor`, but the issue asks for examination rather than a replacement rule. Current canonical `csl-orig/v02/pw/pw.txt` has 27 self-closing `<sic/>` markers; no exact safe normalization was identified. Decision: `needs-human-review` / review-only.
+  - PWK #65 "pwbib title improvement for 'xx' type": `markup`, `minor`. Issue body says `pwbib_parse0.py` already adjusted `xx` titles and comments say abbreviation adjustment is complex/beyond current resolution. Local `pw_ls/pwbib/pwbib1.txt` has the expected `xx` rows and `pwbib_parse0.py` documents the title adjustment behavior. Decision: `needs-human-review` / no patch without explicit abbreviation policy.
   - PWK #66 "•»s.u. markup question": `question`, `minor`. Evidence from the issue thread and local PWK abbreviation work shows `s.u.` = Latin *sub voce* ("see under") and current markup normalizes it as `<ab>s. u.</ab>` / `<ab>s.u.</ab>` in prior issue work. Decision: `answer-only` unless display/link behavior is currently wrong.
+  - PWK #67 "Missing markup": `markup`, `minor`. Issue example asks about unbolded `Simpl.`. Current `csl-orig/v02/pw/pw.txt` has `Simpl.` marked as `<ab>Simpl.</ab>` at the cited-style examples, and later issue88 abbreviation work includes `Simpl.` in `pwkissues/issue88/ablists/global.abbr.pwk.txt` plus change files converting plain `Simpl.`. Decision: already-covered/stale for the cited pattern; future work should find a new active unmarked abbreviation.
   - PWK markup-fix audit singleton candidates (`{%des%}<is>Agni</is>` and `</ls>.[Page...]`) are stale in current `csl-orig/v02/pw/pw.txt`; both boundaries already contain the missing spaces.
   - MWS markup candidates were not promoted in this batch because the local worktree contains unrelated untracked preface/scans output and the sampled issue (#178) points back to a discussion thread rather than an exact local source replacement.
   - csl-orig text-correction candidate #1537 was not promoted because the live issue fetch was intermittent and no exact old/new line-level change was established during triage.
@@ -24,3 +30,4 @@
 
 - [x] 2026-06-27: Ran first conservative Cologne issue-batch triage across PWK/MWS/AP90/PWG/SKD/VCP/csl-orig lanes; no source edits made because no candidate passed all safety gates.
 - [x] 2026-06-27: Classified PWK #66 as `answer-only`: `s.u.` is a sub-voce cross-reference convention; next work, if any, belongs to display/link verification.
+- [x] 2026-06-27: Expanded PWK minor-issue triage to #12, #15, #65, and #67; all failed safe-edit gates, with #12/#67 stale in current source and #15/#65 requiring human bibliography/link-resolution judgment.

--- a/pw_ls/pwbib/jachertz/README.md
+++ b/pw_ls/pwbib/jachertz/README.md
@@ -1,0 +1,101 @@
+# Jachertz 1983 — digitized MA thesis on the textual basis of PW/pw
+
+_Created: 02-07-2026 · Last updated: 02-07-2026_
+
+This folder holds the digitized **Magisterarbeit** of Thomas Jachertz, the
+single most detailed reconstruction of *which editions* the Petersburg
+dictionaries actually quote. This note records what is here, how it compares to
+the [`pwbib`](https://github.com/sanskrit-lexicon/PWK/tree/master/pw_ls/pwbib)
+"list of works" digitization, what value is still untapped, and the timeline.
+
+## The work
+
+> Jachertz, Thomas. 1983. *Beiträge zu einer bibliographischen Übersicht über
+> die textliche Basis unserer europäischen Sanskritwörterbücher, vorzüglich des
+> grossen Petersburger Wörterbuches (PW) und des kleinen Petersburger
+> Wörterbuches (pw)*. Magisterarbeit, vorgelegt im Sommersemester 1983.
+
+It is the reference the CDSL narrative report cites as "the first attempt of its
+kind" for documenting, under one abbreviation, the several editions a Petersburg
+dictionary silently used
+([`csl-observatory/article/00-report-narrative.md`](https://github.com/sanskrit-lexicon/csl-observatory/blob/main/article/00-report-narrative.md), §5.1.4, §5.1.6).
+
+## Files here
+
+| File | What it is |
+|---|---|
+| [`orig/pw-jachertz-dropbox.txt`](https://github.com/sanskrit-lexicon/PWK/blob/master/pw_ls/pwbib/jachertz/orig/pw-jachertz-dropbox.txt) | Full transcription — 3,411 lines, a `Vorwort` + 5 chapters + the A–Z bibliography. Markup: `<title>`, `<h1>`, `<p>`, `<b>` (headwords), `<i>`; 60 `[pwjN]` editorial annotations. **Encoding: cp1252** (mojibake — convert with [`cp1252-to-utf8.py`](https://github.com/sanskrit-lexicon/PWK/blob/master/pw_ls/pwbib/cp1252-to-utf8.py)). Last updated 2015-11-16. |
+| [`orig/pwj.pdf`](https://github.com/sanskrit-lexicon/PWK/blob/master/pw_ls/pwbib/jachertz/orig/pwj.pdf) | 2.3 MB scan of the thesis. |
+
+## How it compares to the `pwbib` "list of works"
+
+Two different objects. [`pwbib`](https://github.com/sanskrit-lexicon/PWK/tree/master/pw_ls/pwbib)
+digitizes the bare **list-of-works pages printed in the six PW volumes**
+(from Thomas Malten, 2003; delivered 2015). Jachertz is the **scholarly
+resolution** of what those abbreviations point to — specific editions, editors,
+places, years, physical copies, and which dictionary used them.
+
+| | `pwbib` ([`mergebibnew.txt`](https://github.com/sanskrit-lexicon/PWK/blob/master/pw_ls/pwbib/pwbib_new_work/mergebibnew.txt)) | Jachertz ([`pw-jachertz-dropbox.txt`](https://github.com/sanskrit-lexicon/PWK/blob/master/pw_ls/pwbib/jachertz/orig/pw-jachertz-dropbox.txt)) |
+|---|---:|---:|
+| Entries | 790 rows | 1,169 bold entries |
+| Carry an edition **year** | 86 | 298 |
+| **India Office (I.O.) shelfmarks** | 0 | 175 |
+| `PW` / `pw` usage tags | — | 296 / 372 |
+| Multiple editions per abbreviation | no | yes (`1. Ed. … 2. Ed. …`) |
+| **Unresolved stubs** (`flag=0`, title `?`) | **287 of 790 (36 %)** | — |
+
+Example — the same class of work in each:
+
+```
+pwbib :  APAST.GAUT:A7PAST.GAUT:530:0:?            # abbreviation only, no title
+Jachertz: <b>Aitareyabra1hman2a</b>
+          --...2. Ed. M. Haug, Bombay, 1863. [I.O. 59] pw [pwj14]
+          --...Ed. R. Roth und D. Whitney, Berlin, 1855. [I.O. 213] PW, pw …
+```
+
+## Untapped value
+
+**Jachertz is digitized but not integrated.** No script in
+[`pwbib`](https://github.com/sanskrit-lexicon/PWK/tree/master/pw_ls/pwbib)
+consumes it; the only trace in the working data is a single hand lookup
+(`ARG4 … title=Arjunasamāgama [Jachertz]` in
+[`bibnew_disp2_edit.txt`](https://github.com/sanskrit-lexicon/PWK/blob/master/pw_ls/pwbib/pwbib_new_work/bibnew_disp2_edit.txt)) —
+proof that Jachertz resolves gaps the printed list cannot, done once, by hand.
+
+Two concrete, un-done uses:
+
+1. **Backfill the 287 unresolved `pwbib` stubs.** Spot-checks confirm the
+   missing works are in Jachertz (e.g. `ANUPADAS` → "Anupadasūtra";
+   `ANUKR` → "Anukramaṇikā"). A headword join Jachertz → `pwbib` abbreviations
+   could resolve a large share of the 36 % that are currently bare.
+2. **Edition + shelfmark disambiguation for link targets.** The Dictionary-to-Book
+   work needs to know *which* scanned edition a PW/pw citation points to when an
+   abbreviation covers several editions. Jachertz's per-edition data (editor,
+   place, year) and its 175 India Office shelfmarks are exactly that layer, and
+   are not yet in the linking pipeline.
+
+## Timeline
+
+| Date | Milestone |
+|---|---|
+| 1818 | Bonn chair of Indology — Jachertz's baseline for German Sanskrit lexicography |
+| 1819 / 1832 | Wilson, *A Dictionary in Sanscrit and English* (1st / revised) |
+| 1852–1875 | **PW** — *Großes Petersburger Wörterbuch*, 7 parts (Böhtlingk & Roth) |
+| 1879–1889 | **pw** — *Sanskrit-Wörterbuch in kürzerer Fassung* (Böhtlingk) |
+| **SS 1983** | **Jachertz submits the Magisterarbeit** — first systematic overview of the editions underlying PW/pw |
+| 2003 | Malten digitizes the PW "list of works" (six volumes) → later [`pwbib_orig.txt`](https://github.com/sanskrit-lexicon/PWK/blob/master/pw_ls/pwbib/pwbib_orig.txt) |
+| 2015-11-16 | Malten delivers `pwbib_orig.txt` (cp1252); the Jachertz transcription is finalized; the [`pw_ls`](https://github.com/sanskrit-lexicon/PWK/tree/master/pw_ls) work opens (parse regularization = [PWK issue #14](https://github.com/sanskrit-lexicon/PWK/issues/14)) |
+| 2016 (Jan–Aug) | `pwbib` pipeline: UTF-8 convert → parse (502 lines) → fuzzy match → citation↔bibliography reconciled to **0 unmatched citations** (459 matched) → [`mergebibnew.txt`](https://github.com/sanskrit-lexicon/PWK/blob/master/pw_ls/pwbib/pwbib_new_work/mergebibnew.txt) (790) → display prep (sqlite + static HTML) |
+| 2016-08-05 | Last `pwbib` commit — the line of work goes dormant (the live bib-hyperlinks in the PWK display were prepared but never wired into `disp.php`) |
+| 2026-07-02 | Citation resolved from this primary source and added to the A13 References ([csl-observatory PR #68](https://github.com/sanskrit-lexicon/csl-observatory/pull/68)); this note written |
+
+## State, in one line
+
+The Jachertz thesis is **fully transcribed + scanned** (needs a one-shot
+cp1252→UTF-8 pass to be publication-ready); the `pwbib` citation↔bibliography
+reconciliation is **essentially complete** (0 unmatched citations); but the
+richest layer — Jachertz's edition and shelfmark data — is **digitized and
+sitting unused**, and the PWK web-display hyperlinks it was meant to power were
+never deployed. Both are concrete, resumable unblocks.
+
+_Dr. Mārcis Gasūns_


### PR DESCRIPTION
Adds [`pw_ls/pwbib/jachertz/README.md`](https://github.com/sanskrit-lexicon/PWK/blob/master/pw_ls/pwbib/jachertz/README.md) documenting the digitized Jachertz 1983 Magisterarbeit that sits in this folder.

**Why:** the citation was just resolved from this primary source (csl-observatory [PR #68](https://github.com/sanskrit-lexicon/csl-observatory/pull/68)), and exploring the folder surfaced an untapped data asset worth recording.

**Contents:** the full citation; the files here (transcription + PDF scan); a field-by-field **comparison to the `pwbib` "list of works"**; the **untapped-value** finding; and a **timeline** (1818 → 2026).

**Headline finding — Jachertz is digitized but not integrated:**
- No `pwbib` script consumes it; the only trace is one hand lookup (`ARG4 … [Jachertz]`).
- Jachertz is far richer than `pwbib`'s printed list: **1,169 entries, 298 with edition years, 175 India-Office shelfmarks, PW/pw usage tags, multiple editions per abbreviation** — versus `pwbib`'s 790 rows, of which **287 (36 %) are unresolved stubs** (`flag=0`, title `?`).
- Two concrete un-done uses: (1) backfill the 287 unresolved `pwbib` titles from Jachertz (spot-checks confirm the works are present); (2) supply the per-edition + shelfmark layer the Dictionary-to-Book link targets need to disambiguate *which* scanned edition a citation points to.

Doc-only; follows the repo doc contract (dated header, full blob URLs, byline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
