### PR TITLE
Unblock Jachertz 1983: UTF-8 pass + structured parse + pwbib backfill candidates

### DIFF
--- a/pw_ls/pwbib/jachertz/README.md
+++ b/pw_ls/pwbib/jachertz/README.md
@@ -5,7 +5,7 @@ _Created: 02-07-2026 · Last updated: 02-07-2026_
 This folder holds the digitized **Magisterarbeit** of Thomas Jachertz, the
 single most detailed reconstruction of *which editions* the Petersburg
 dictionaries actually quote. This note records what is here, how it compares to
-the [`pwbib`](https://github.com/sanskrit-lexicon/PWK/tree/master/pw_ls/pwbib)
+the [`pwbib`](https://github.com/sanskrit-lexicon/PWK/tree/main/pw_ls/pwbib)
 "list of works" digitization, what value is still untapped, and the timeline.
 
 ## The work
@@ -24,18 +24,18 @@ dictionary silently used
 
 | File | What it is |
 |---|---|
-| [`orig/pw-jachertz-dropbox.txt`](https://github.com/sanskrit-lexicon/PWK/blob/master/pw_ls/pwbib/jachertz/orig/pw-jachertz-dropbox.txt) | Full transcription — 3,411 lines, a `Vorwort` + 5 chapters + the A–Z bibliography. Markup: `<title>`, `<h1>`, `<p>`, `<b>` (headwords), `<i>`; 60 `[pwjN]` editorial annotations. **Encoding: cp1252** (mojibake — convert with [`cp1252-to-utf8.py`](https://github.com/sanskrit-lexicon/PWK/blob/master/pw_ls/pwbib/cp1252-to-utf8.py)). Last updated 2015-11-16. |
-| [`orig/pwj.pdf`](https://github.com/sanskrit-lexicon/PWK/blob/master/pw_ls/pwbib/jachertz/orig/pwj.pdf) | 2.3 MB scan of the thesis. |
+| [`orig/pw-jachertz-dropbox.txt`](https://github.com/sanskrit-lexicon/PWK/blob/main/pw_ls/pwbib/jachertz/orig/pw-jachertz-dropbox.txt) | Full transcription — 3,411 lines, a `Vorwort` + 5 chapters + the A–Z bibliography. Markup: `<title>`, `<h1>`, `<p>`, `<b>` (headwords), `<i>`; 60 `[pwjN]` editorial annotations. **Encoding: cp1252** (mojibake — convert with [`cp1252-to-utf8.py`](https://github.com/sanskrit-lexicon/PWK/blob/main/pw_ls/pwbib/cp1252-to-utf8.py)). Last updated 2015-11-16. |
+| [`orig/pwj.pdf`](https://github.com/sanskrit-lexicon/PWK/blob/main/pw_ls/pwbib/jachertz/orig/pwj.pdf) | 2.3 MB scan of the thesis. |
 
 ## How it compares to the `pwbib` "list of works"
 
-Two different objects. [`pwbib`](https://github.com/sanskrit-lexicon/PWK/tree/master/pw_ls/pwbib)
+Two different objects. [`pwbib`](https://github.com/sanskrit-lexicon/PWK/tree/main/pw_ls/pwbib)
 digitizes the bare **list-of-works pages printed in the six PW volumes**
 (from Thomas Malten, 2003; delivered 2015). Jachertz is the **scholarly
 resolution** of what those abbreviations point to — specific editions, editors,
 places, years, physical copies, and which dictionary used them.
 
-| | `pwbib` ([`mergebibnew.txt`](https://github.com/sanskrit-lexicon/PWK/blob/master/pw_ls/pwbib/pwbib_new_work/mergebibnew.txt)) | Jachertz ([`pw-jachertz-dropbox.txt`](https://github.com/sanskrit-lexicon/PWK/blob/master/pw_ls/pwbib/jachertz/orig/pw-jachertz-dropbox.txt)) |
+| | `pwbib` ([`mergebibnew.txt`](https://github.com/sanskrit-lexicon/PWK/blob/main/pw_ls/pwbib/pwbib_new_work/mergebibnew.txt)) | Jachertz ([`pw-jachertz-dropbox.txt`](https://github.com/sanskrit-lexicon/PWK/blob/main/pw_ls/pwbib/jachertz/orig/pw-jachertz-dropbox.txt)) |
 |---|---:|---:|
 | Entries | 790 rows | 1,169 bold entries |
 | Carry an edition **year** | 86 | 298 |
@@ -56,10 +56,10 @@ Jachertz: <b>Aitareyabra1hman2a</b>
 ## Untapped value
 
 **Jachertz is digitized but not integrated.** No script in
-[`pwbib`](https://github.com/sanskrit-lexicon/PWK/tree/master/pw_ls/pwbib)
+[`pwbib`](https://github.com/sanskrit-lexicon/PWK/tree/main/pw_ls/pwbib)
 consumes it; the only trace in the working data is a single hand lookup
 (`ARG4 … title=Arjunasamāgama [Jachertz]` in
-[`bibnew_disp2_edit.txt`](https://github.com/sanskrit-lexicon/PWK/blob/master/pw_ls/pwbib/pwbib_new_work/bibnew_disp2_edit.txt)) —
+[`bibnew_disp2_edit.txt`](https://github.com/sanskrit-lexicon/PWK/blob/main/pw_ls/pwbib/pwbib_new_work/bibnew_disp2_edit.txt)) —
 proof that Jachertz resolves gaps the printed list cannot, done once, by hand.
 
 Two concrete, un-done uses:
@@ -74,6 +74,18 @@ Two concrete, un-done uses:
    place, year) and its 175 India Office shelfmarks are exactly that layer, and
    are not yet in the linking pipeline.
 
+## Unblock (2026-07-02)
+
+The idle layer is now machine-usable. Three artifacts, none of which touch the
+canonical [`pwbib`](https://github.com/sanskrit-lexicon/PWK/tree/main/pw_ls/pwbib)
+data — run [`jachertz_parse.py`](https://github.com/sanskrit-lexicon/PWK/blob/main/pw_ls/pwbib/jachertz/jachertz_parse.py) to regenerate:
+
+1. **cp1252 → UTF-8 pass** — [`orig/pw-jachertz-utf8.txt`](https://github.com/sanskrit-lexicon/PWK/blob/main/pw_ls/pwbib/jachertz/orig/pw-jachertz-utf8.txt) (strict decode, 0 replacement chars, BOM-free). The German is now correct; the AS-numeric Sanskrit (`a1`=ā, `s4`=ś, `n2`=ṇ) is untouched.
+2. **Structured parse** — [`jachertz_bib.tsv`](https://github.com/sanskrit-lexicon/PWK/blob/main/pw_ls/pwbib/jachertz/jachertz_bib.tsv): one row per entry (**1,169** total = 503 works + 626 `s.` cross-references + 40 `=` expansions), each with its editions (**522**), **155 India-Office + 32 Gildemeister shelfmarks**, and PW/pw usage tags. This is the first time the edition/shelfmark layer is queryable rather than prose in a scan.
+3. **Backfill candidates for the 287 `pwbib` stubs** — [`jachertz_backfill_candidates.tsv`](https://github.com/sanskrit-lexicon/PWK/blob/main/pw_ls/pwbib/jachertz/jachertz_backfill_candidates.tsv): a conservative match (exact / `s.`-xref / unique-prefix on a digit-stripped key, since the two data sets use different digit schemes) resolves **37 of 287** unresolved abbreviations — e.g. `PANINI` → Pāṇini (Ed. Böhtlingk, Bonn 1840), `KATANTRA` → Kātantra (Ed. Eggeling, Calcutta 1874), `VEDANTASARA` → Vedāntasāra (2 eds.). **These are candidates for human review, not applied** — `match_how=exact/xref` are solid, `prefix` least certain.
+
+Remaining work (higher-recall, still resumable): a proper AS-scheme normalizer between Jachertz's `a1`/`s4`/`n2` and pwbib's `A7`/`C2`/`S2` would lift the 37/287 match rate well beyond this high-precision floor; and the display-side hyperlinks (`disp.php` ↔ sqlite) were never wired.
+
 ## Timeline
 
 | Date | Milestone |
@@ -83,19 +95,21 @@ Two concrete, un-done uses:
 | 1852–1875 | **PW** — *Großes Petersburger Wörterbuch*, 7 parts (Böhtlingk & Roth) |
 | 1879–1889 | **pw** — *Sanskrit-Wörterbuch in kürzerer Fassung* (Böhtlingk) |
 | **SS 1983** | **Jachertz submits the Magisterarbeit** — first systematic overview of the editions underlying PW/pw |
-| 2003 | Malten digitizes the PW "list of works" (six volumes) → later [`pwbib_orig.txt`](https://github.com/sanskrit-lexicon/PWK/blob/master/pw_ls/pwbib/pwbib_orig.txt) |
-| 2015-11-16 | Malten delivers `pwbib_orig.txt` (cp1252); the Jachertz transcription is finalized; the [`pw_ls`](https://github.com/sanskrit-lexicon/PWK/tree/master/pw_ls) work opens (parse regularization = [PWK issue #14](https://github.com/sanskrit-lexicon/PWK/issues/14)) |
-| 2016 (Jan–Aug) | `pwbib` pipeline: UTF-8 convert → parse (502 lines) → fuzzy match → citation↔bibliography reconciled to **0 unmatched citations** (459 matched) → [`mergebibnew.txt`](https://github.com/sanskrit-lexicon/PWK/blob/master/pw_ls/pwbib/pwbib_new_work/mergebibnew.txt) (790) → display prep (sqlite + static HTML) |
+| 2003 | Malten digitizes the PW "list of works" (six volumes) → later [`pwbib_orig.txt`](https://github.com/sanskrit-lexicon/PWK/blob/main/pw_ls/pwbib/pwbib_orig.txt) |
+| 2015-11-16 | Malten delivers `pwbib_orig.txt` (cp1252); the Jachertz transcription is finalized; the [`pw_ls`](https://github.com/sanskrit-lexicon/PWK/tree/main/pw_ls) work opens (parse regularization = [PWK issue #14](https://github.com/sanskrit-lexicon/PWK/issues/14)) |
+| 2016 (Jan–Aug) | `pwbib` pipeline: UTF-8 convert → parse (502 lines) → fuzzy match → citation↔bibliography reconciled to **0 unmatched citations** (459 matched) → [`mergebibnew.txt`](https://github.com/sanskrit-lexicon/PWK/blob/main/pw_ls/pwbib/pwbib_new_work/mergebibnew.txt) (790) → display prep (sqlite + static HTML) |
 | 2016-08-05 | Last `pwbib` commit — the line of work goes dormant (the live bib-hyperlinks in the PWK display were prepared but never wired into `disp.php`) |
 | 2026-07-02 | Citation resolved from this primary source and added to the A13 References ([csl-observatory PR #68](https://github.com/sanskrit-lexicon/csl-observatory/pull/68)); this note written |
 
 ## State, in one line
 
-The Jachertz thesis is **fully transcribed + scanned** (needs a one-shot
-cp1252→UTF-8 pass to be publication-ready); the `pwbib` citation↔bibliography
-reconciliation is **essentially complete** (0 unmatched citations); but the
-richest layer — Jachertz's edition and shelfmark data — is **digitized and
-sitting unused**, and the PWK web-display hyperlinks it was meant to power were
-never deployed. Both are concrete, resumable unblocks.
+The Jachertz thesis is **fully transcribed + scanned**; as of 2026-07-02 it is
+also **converted to UTF-8 and parsed into a structured table** (see the Unblock
+section) — the edition/shelfmark layer is now queryable, and a first
+high-precision pass backfilled 37 of the 287 unresolved `pwbib` stubs. The
+`pwbib` citation↔bibliography reconciliation was already **essentially complete**
+(0 unmatched citations). Two resumable follow-ups remain: a full AS-scheme
+normalizer to raise the backfill recall, and wiring the prepared bib-hyperlinks
+into the PWK web display (`disp.php` ↔ sqlite), which were never deployed.
 
 _Dr. Mārcis Gasūns_

--- a/pw_ls/pwbib/jachertz/jachertz_backfill_candidates.tsv
+++ b/pw_ls/pwbib/jachertz/jachertz_backfill_candidates.tsv
@@ -1,0 +1,38 @@
+pwbib_abbrv	pwbib_id	match_how	jachertz_head	editions	io_shelfmarks	gild_shelfmarks
+ANANDAGIRI	649	exact	A1nandagiri	Ein Kommentator der Br2hada1ran2yaka Upanis2ad. PW, pw		
+ANUPADA	762	prefix	Anupadasu1tra	Ohne weiteres im PW.		
+ANUPADAS	669	prefix	Anupadasu1tra	Ohne weiteres im PW.		
+ARG	780	xref	Arjunasama1gama	Liber sine titulo. Ed. F. Bopp, Berlin, 1829.  PW, pw Mit		106
+AV.ANUKR	696	xref	Atharvaveda	Ed. R. Roth und D. Whitney, Berlin, 1855.  PW, pw Mit Anukraman2ika1 (10 Pat2ala)	213	
+AV.PRAT	637	xref	Atharvaveda	Ed. R. Roth und D. Whitney, Berlin, 1855.  PW, pw Mit Anukraman2ika1 (10 Pat2ala)	213	
+BHAG	612	xref	Bhagavadgi1ta1	Ed. A. Schlegel, Bonn, 1846.  PW, pw		116
+BHAR	541	xref	Bharata	Ein Autor über Schauspielkunst. Handschrift? PW		
+BHAR.NATJAC	710	xref	Bha1rati1yana1t2yas4a1stra	In Halls Das4aru1pa am Ende. pw		
+BHARATA	607	exact	Bharata	Ein Autor über Schauspielkunst. Handschrift? PW		
+BRAHMAN	628	prefix	Bra1hma1n2d2a Pura1n2a	Ohne weiteres im PW		
+BRHASPATI	584	exact	Br2haspati	Verfasser eines Gesetzbuches nach Anführungen im Mita1ks2ara und		
+BURNELL	742	prefix	Burnell, T.			
+GJOT	761	xref	Jyotis2am	Uber den Vedakalender namens Jyotis2am. Von A. Weber, Berlin, 1862. pw		
+HIOUEN-THSANG	758	exact	Hiouen Thsang	1. Histoire de la vie de Hiouen Thsang et de ses voyages		
+JOLLY	653	xref	Indisches Schuldrecht	Von J. Jolly, Münchner philos. --phil. Abhandlungen, 1877. S. 528ff pw		
+KAIJ	605	xref	Kaiyata	Ein Kommentator zum Maha1bha1s2ya. PW		
+KATANTRA	627	exact	Ka1tantra	Ed. J. Eggeling, Calcutta, 1874.  pw	1282	
+KIELHORN	672	exact	Kielhorn			
+MAC	783	xref	Mas4aka Kalpasu1tra	Ohne weiteres im PW.		
+MAHAN	590	xref	Maha1na1t2aka	Ed. K. Kr2s2n2a Bahadur, Calcutta, 1840.  PW		220
+MALLIN	511	xref	Mallina1tha	Ein Kommentator des Ka9lida1sa. PW, pw		
+MANU	544	exact	Manu			
+OPPERT	635	exact	Oppert			
+PANINI	694	exact	Pa1n2ini	Ed. O. Böhtlingk, Bonn, 1840. PW, pw Mit: Va1rtika1s von Ka1tya1yana		
+PAT	555	xref	Patan5jali	1. Verfasser des Maha1bha1s2ya. In Böhtlingks Pa1n2ini. | 2. s. Yogasu1tra		
+RAJAM	775	xref	Ra1yamukuta	Ein Kommentator des Amarakos4a, nach Anführungen im S4KD. PW		
+RAJENDR.NOT	618	xref	Notices			
+TANTRAS	543	xref	Tantrasa1ra	Nach Anführungen im S4KD. PW		
+TANTRASARA	766	exact	Tantrasa1ra	Nach Anführungen im S4KD. PW		
+UPALEKHA	582	exact	Upalekha	Ed. W. Pertsch, Berlin, 1854.  PW	2796	
+VARAH	751	prefix	Vara1ha Pura1n2a	Handschrift. PW, pw		
+VEDANTASARA	664	exact	Veda1ntasa1ra	1. Ed. Calcutta, 1829.  PW | 2. Ed. J. R. Ballantyne, Allahabad, 1850.  PW	2937	279
+VERZ.D.PET.H	722	xref	St. Petersburg			
+VIRAMITROD	693	prefix	Vi1ramitrodaya	Ed. Calcutta, 1815.  PW, pw	3005	
+VIVEK	652	prefix	Vivekavila1sa	In der Zeitschrift Pratnakamranandini1. pw		
+WILSON	574	prefix	Wilson, H.H.			

--- a/pw_ls/pwbib/jachertz/jachertz_bib.tsv
+++ b/pw_ls/pwbib/jachertz/jachertz_bib.tsv
@@ -1,0 +1,1170 @@
+head_as	key	type	target	n_ed	editions	io_shelfmarks	gild_shelfmarks	dicts
+Abhidha1nacinta1man2i1	ABHIDHANACINTAMANI	work		1	Von Hemacandra. Ed. O. Böhtlingk und Ch. Rieu, St. Petersburg, 1847.  PW, pw	5		PW,pw
+A1ca1radars4a	ACARADARSA	work		1	Von S4ri1datta. Ed. Benares, 1821. pw			pw
+A1cha1ra1n9gasu1tra	ACHARANGASUTRA	work		2	Von S4i1lan3ka, Ed. Bombay, 1895. pw | Von Sudharmasva1min. Ed. Bombay, 1895.  pw	21,21		pw
+A1c11v.C11r.	ACVCR	xref	A1s4vala1yanas4rautasu1tra	0				
+A1c11v.Gr2hj.	ACVGRHJ	xref	A1s4vala1yanagr2hyasu1tra	0				
+Adbh.Br.	ADBHBR	xref	Adbhutabra1hman2a	0				
+Adbhutabra1hman2a	ADBHUTABRAHMANA	work		1	Ed. A. Weber, Berlin, 1858.  PW	27		PW
+Adbhutas.	ADBHUTAS	xref	Adbhutasa1ra	0				
+Adbhutasa1ra	ADBHUTASARA	work		1	Ohne weiteres im PW.			PW
+Adhima1sanirn2aya	ADHIMASANIRNAYA	work		1	Ohne weiteres im pw.			pw
+Agni-P.	AGNIP	xref	Agnipura1n2a	0				
+Agnipura1n2a	AGNIPURANA	work		1	Ed. R. Mitra, Calcutta, 1873-79.  pw	53		pw
+A1hnikat.	AHNIKAT	xref	A1hnikatattva	0				
+A1hnikatattva	AHNIKATATTVA	work		1	Ohne weiteres im PW.			PW
+Ainslie	AINSLIE	xref	Materia indica	0				
+Ait.A1r.	AITAR	xref	Aitareyaran2yaka	0				
+Aitareya1ran2yaka	AITAREYARANYAKA	work		2	1. Nach Mitteilungen von A. Weber. PW | 2. Ed. R. Mitra, (alcutta, 1876.  pw	58		PW,pw
+Aitareyabra1hman2a	AITAREYABRAHMANA	work		2	1. Handschrift mit Sa1yan2as Kommentar. PW | 2. Ed. M. Haug, Bombay, 1863.  pw	59		PW,pw
+Aitareya Upanis2ad	AITAREYAUPANISAD	xref	Taittiri1ya Upanis2ad.	0				
+Ait.Br.	AITBR	xref	Aitareyabra1hman2a	0				
+Ait.Up.	AITUP	xref	Aitareya Upanis2ad	0				
+AK.	AK	xref	Amarakos2a	0				
+Akademische Vorlesungen	AKADEMISCHEVORLESUNGEN	work		1	Von A. Weber, Berlin, 1852. PW; 1876. pw			PW
+Alam2ka1raratna1kara	ALAMKARARATNAKARA	work		1	Von S4obha1kara. Deccan Collection, Handschrift Nr. 227. pw			pw
+Alam2ka1rasarvasva	ALAMKARASARVASVA	work		1	Von Ruyyaka. Deccan Collection, Handschrift Nr. 231. pw			pw
+Alam2ka1ras4ekhara	ALAMKARASEKHARA	work		1	Von Kes4avamis4ra. Lith. Ausgabe Benares, 1833. pw			pw
+Alam2ka1ratilaka	ALAMKARATILAKA	work		1	Handschrift. pw			pw
+Alam2ka1ravimars4in2i1	ALAMKARAVIMARSINI	work		1	Von Jayaratha. Deccan Collection, Handschrift Nr. 230. pw			pw
+Algebra	ALGEBRA	work		1	Von H. T. Colebrooke, London, 1817.  PW, pw	75		PW,pw
+Amarad.	AMARAD	xref	Amaradatta	0				
+Amaradatta	AMARADATTA	work		1	Ein Lexikograph. [Vogel 321, 347, 348] PW			PW
+Amarakos4a	AMARAKOSA	work		2	1. Ed. H. T. Colebrooke, Serampore, 1808. 1825.  PW | 2. Ed. A. L. Deslongchamps, Paris, 1839-45.  PW, pw	1698,1699		PW,PW,pw
+Amarus4ataka	AMARUSATAKA	work		1	Ed. Calcutta, 1808.  PW Mit Ghat2akarpara.		162	PW
+Amr2tavindu1panis2ad	AMRTAVINDUPANISAD	xref	Atharvan2a Upanis2ads	0				
+Amr2tav.Up.	AMRTAVUP	xref	Amr2tavindu1panis2ad	0				
+an.	AN	xref	Aneka1rthasam2graha	0				
+A1andag.	AANDAG	xref	A1nandagiri	0				
+A1nandagiri	ANANDAGIRI	work		1	Ein Kommentator der Br2hada1ran2yaka Upanis2ad. PW, pw			PW,pw
+A1nandal.	ANANDAL	xref	A1nandalahari1	0				
+A1nandalahari1	ANANDALAHARI	xref	Ka1vyasam2graha	0				
+A1nandav.	ANANDAV	xref	A1nandavalli1	0				
+A1nandavalli1 (Brahmavalli1)	ANANDAVALLIBRAHMAVALLI	work		1	Zur Taittiri1ya Upanis2ad  PW	107		PW
+Anarghara1ghava	ANARGHARAGHAVA	work		1	Ed. Premachandra Tarkava1gi1s4a, Calcutta, 1860.  pw	119		pw
+Aneka1rthadhv.	ANEKARTHADHV	xref	Aneka1rthadhvaniman5jari1	0				
+Aneka1rthadhvaniman5jari1	ANEKARTHADHVANIMANJARI	work		1	Ein Wörterbuch, aufgeführt im S4KD. [Vogel 319] PW			PW
+Aneka1rthasam2graha	ANEKARTHASAMGRAHA	work		1	Von Hemacandra. Ed. H. T. Colebrooke, Calcutta, 1807. PW, pw		259	PW,pw
+Aneka1rthasamuccaya	ANEKARTHASAMUCCAYA	work		1	Von S4a1s4vata. Ed. Th. Zachariae, Berlin, 1882. pw	121		pw
+Anh.	ANH	abbrev	Anhang	0				
+Annam2bh.	ANNAMBH	xref	Annam2bhat2t2a	0				
+Annam2bhat2t2a	ANNAMBHATTA	work		1	Zum Tarkasam2graha.  PW	2713		PW
+Anthologia sanscritica	ANTHOLOGIASANSCRITICA	work		1	Von Chr. Lassen, Bonn, 1838. 1868.  PW, pw Mit Brahmapura1n2a	121		PW,pw
+Anukr.	ANUKR	abbrev	Anukraman2ika1	0				
+Anup.s.	ANUPS	xref	Anupadasu1tra	0				
+Anupadasu1tra	ANUPADASUTRA	work		1	Ohne weiteres im PW.			PW
+Apara1rka	APARARKA	work		1	Zur Ya1jn5avalkyasmr2ti.  pw	31000		pw
+A1past.	APAST	xref	A1pastamba	0				
+A1pastamba	APASTAMBA	work		0				
+A1pastamba S4rautasu1tra	APASTAMBASRAUTASUTRA	work		1	Handschrift. pw			pw
+A1past.C11r.	APASTCR	xref	A1pastamba S4rautasu1tra	0				
+Archaeological Survey	ARCHAEOLOGICALSURVEY	work		1	of India, pw			pw
+Ar4g.	ARG	xref	Arjunasama1gama	0				
+A1rjav.	ARJAV	xref	A1ryavidya1sudha1kara	0				
+Arjunasama1gama	ARJUNASAMAGAMA	work		1	Liber sine titulo. Ed. F. Bopp, Berlin, 1829.  PW, pw Mit		106	PW,pw
+A1rsh.Br.	ARSHBR	xref	A1rs2eyabra1hman2a	0				
+A1rs2eyabra1hman2a	ARSEYABRAHMANA	work		1	Ed. A. C. Burnell, Mangalore, 1876.  pw	162		pw
+A1run2eya Upanis2ad	ARUNEYAUPANISAD	xref	Atharvan2a Upanis2ads	0				
+A1run2ika Upanis2ad	ARUNIKAUPANISAD	work		1	Ohne weiteres im PW.			PW
+A1run2.Up.	ARUNUP	xref	A1run2eya Upanis2ad und A1run2ika Upanis2ad	0				
+A1ryabhat2t2i1ya	ARYABHATTIYA	work		1	Ed. H. Kern, Leyden, 1874.  pw	169		pw
+A1ryaman5jus4ri1na1masan2gi1 ti1	ARYAMANJUSRINAMASANGITI	work		1	Im Verzeichnis der Petersburger Sanskrithandschriften Nr. 121. PW			PW
+A1ryavidya1sudha1kara	ARYAVIDYASUDHAKARA	work		1	Ed. Cimana Bhat2t2a, Bombay, 1868.  pw	175		pw
+Asaha1ya	ASAHAYA	work		1	Ein Kommentator des Narada. pw			pw
+As.	AS	xref	Asiatic Researches	0				
+Asiatic Researches	ASIATICRESEARCHES	work		1	or Transactions of the Society instituted in Bengal, for inquiring into			
+A1s4vala1yana Gr2hyasu1t4a	ASVALAYANAGRHYASUTA	work		2	1. Handschrift in 4 Adhya1ya. PW | 2. Ed. A. F. Stenzler, Leipzig, 1864-65.  pw	204		PW,pw
+A1s4vala1yana S4rautasu1tra	ASVALAYANASRAUTASUTRA	work		2	1. Handschrift in 4 Adhya1ya. PW | 2. Ed. R. Vidya1ratna, Calcutta. 1864-75.  pw	207		PW,pw
+Atharvan2a Upanis2ads	ATHARVANAUPANISADS	work		1	Ed. R. Tarkaratna, Calcutta, 1872-74.  PW, pw Mit	2811		PW,pw
+Atharvaveda	ATHARVAVEDA	work		1	Ed. R. Roth und D. Whitney, Berlin, 1855.  PW, pw Mit Anukraman2ika1 (10 Pat2ala)	213		PW,pw
+Atharvaveda der Paippala1da-Schule	ATHARVAVEDADERPAIPPALADASCHULE	work		1	Handschrift. pw			pw
+A1tma Upanis2ad	ATMAUPANISAD	xref	Atharvan2a Upanis2ada	0				
+A1tmop.	ATMOP	xref	A1tma Upanis2ad	0				
+Aucitya1lam2ka1ra	AUCITYALAMKARA	work		1	Ohne weiteres im pw			pw
+Aupapa1tikasu1tra	AUPAPATIKASUTRA	work		1	Ed. L. Leumann, Leipzig, 1883.  pw	238		pw
+AV.	AV	xref	Atharvaveda	0				
+Avada1nas4ataka	AVADANASATAKA	work		1	Eine buddhistische Legendensammlung. PW			PW
+Avad.C11at.	AVADCAT	xref	Avada1nas4ataka	0				
+AV.Anukr.	AVANUKR	xref	Atharvaveda	0				
+AV.Gjot.	AVGJOT	xref	Jyotis2a zum Atharvaveda	0				
+avj.	AVJ	abbrev	avyaya (zum Medini1kos4a)	0				
+AV. Paipp.	AVPAIPP	xref	Atharvaveda der Paippala1da Schule	0				
+AV. Paric11.	AVPARIC	xref	Atharvaveda	0				
+AV.Pra1jac11k4.	AVPRAJACK	xref	Atharvaveda	0				
+AV.Pra1t.	AVPRAT	xref	Atharvaveda	0				
+Avyaya1neka1rthavarga	AVYAYANEKARTHAVARGA	xref	Medini1kos4a	0				
+Ba1dar.	BADAR	xref	Ba1dara1yan2a	0				
+Ba1dara1yan2a	BADARAYANA	xref	Brahmasu1tra	0				
+B. A. J.	BAJ	abbrev	Bombay Asiatic Journal pw	0				
+Ba1labodhani1	BALABODHANI	xref	S4am2kara	0				
+Ba1lar.	BALAR	xref	Ba1ara1ma1yan2a	0				
+Ba1lara1ma1yan2a	BALARAMAYANA	work		1	Ed. G. S4a1stri1, Benares, 1869.  pw	269		pw
+Baudh.	BAUDH	xref	Baudha1yana	0				
+Baudha1yana	BAUDHAYANA	work		1	Eine Schule zum schwarzen Yajurveda. Nach Zitaten in anderen Werken und			
+Benf.Chr.	BENFCHR	xref	Handbuch der Snskritsprache	0				
+Benf.Gr.	BENFGR	xref	Handbuch der Sanskritsprache	0				
+Berichte d.k.s.Ges.d.Ww.	BERICHTEDKSGESDWW	abbrev	Berichte der königlich sächsischen	0				
+Berlin:	BERLIN	work		0				
+Berl.Mon.	BERLMON	xref	Monatsbericht	0				
+Bhadraba1hucarita	BHADRABAHUCARITA	work		1	Ed. H. Jacobi, in: Z. d. d. m. G. 38, 19ff. pw			pw
+Bhag.	BHAG	xref	Bhagavadgi1ta1	0				
+Bhagana1dya1ya	BHAGANADYAYA	work		1	Ohne weiteres im pw.			pw
+Bhagavadgi1ta1	BHAGAVADGITA	work		1	Ed. A. Schlegel, Bonn, 1846.  PW, pw		116	PW,pw
+Bha1gavatapura1n2a	BHAGAVATAPURANA	work		1	Ed. E. Burnouf, Paris, 1840-44. <i>I.O. 359] PW, pw 9Skandha von U1ran			PW,pw
+Bhagavati1	BHAGAVATI	work		1	Ed. A. Weber, Berlin, 1866.  pw	2777		pw
+Bha1g.P.	BHAGP	xref	Bha1gavatapura1n2a	0				
+4Bha1m.	BHAM	xref	Bha1mati1	0				
+Bha1mati1	BHAMATI	work		1	Ed. Ba1las4a1stri1, 1876-80.  pw	521		pw
+Bha1mini1vila1sa	BHAMINIVILASA	work		1	Ed. A. Bergaigne, Paris, 1872.  pw	400		pw
+Bha1m.V.	BHAMV	xref	Bha1mini1vila1sa	0				
+Bha1nud.	BHANUD	xref	Bha1nudi1ks2ita	0				
+Bha1nudi1ks2ita	BHANUDIKSITA	work		1	Ein Kommentator des Amarakos4a. PW			PW
+Bhar.	BHAR	xref	Bharata	0				
+Bharata	BHARATA	work		1	Ein Autor über Schauspielkunst. Handschrift? PW			PW
+Bharat2akadvatr2m2s4ika1	BHARATAKADVATRMSIKA	work		1	Handschrift. pw			pw
+Bha1rati1yana1t2yas4a1stra	BHARATIYANATYASASTRA	work		1	In Halls Das4aru1pa am Ende. pw			pw
+Bha1r.Na1t2jac11.	BHARNATJAC	xref	Bha1rati1yana1t2yas4a1stra	0				
+Bhartr2.	BHARTR	xref	Bhartr2hari	0				
+Bhartr2hari	BHARTRHARI	work		1	Ed. P. A. Bohlen, Berlin, 1833PW,pw Mit		156	PW,pw
+Bha1s2apariccheda	BHASAPARICCHEDA	work		1	Ed. E. Röer, Calcutta, 1850.  PW, pw	422		PW,pw
+Bha1s2ap.	BHASAP	xref	Bha1s2apariccheda	0				
+Bha1skara	BHASKARA	xref	Siddha1ntas4iroman2i und Li1la1vati1 [pwj19]	0				
+Bhat2t2.	BHATT	xref	Bhat2t2ika1vya	0				
+Bhat2t2ika1vya	BHATTIKAVYA	work		1	Ed. Calcutta, 1828.  PW, pw	2165		PW,pw
+Bha1vapr.	BHAVAPR	xref	Bha1vapraka1s4a	0				
+Bha1vapraka1s4a	BHAVAPRAKASA	work		3	1. Nach Anführungen im S4KD. PW | 2. J. Vidya1sa1gara, Calcutta, 1875.  pw | 3. Handschrift. pw	438		PW,pw
+Bhavishjott.	BHAVISHJOTT	xref	Bhavis2yottama Pura1n2a	0				
+Bhavis2yapura1n2a	BHAVISYAPURANA	work		1	Handschrift. PW, pw			PW,pw
+Bhavis2yottama Pura1n2a	BHAVISYOTTAMAPURANA	work		1	Nach Zitaten in anderen Werken and nach Mitteilungen von Th. Aufrecht. pw			pw
+Bhav.Pur.	BHAVPUR	xref	Bhavis2yapura1n2a	0				
+Bhog4a K.	BHOGAK	xref	Bhojacarita	0				
+Bhojacarita	BHOJACARITA	work		1	Ed. Madras, 1862. pw			pw
+Bhojaprabandha	BHOJAPRABANDHA	work		1	Ed. Benares, 1868.  pw	449		pw
+Bhu1ripr.	BHURIPR	xref	Bhu1riprayoga	0				
+Bhu1riprayo1ga	BHURIPRAYOGA	work		1	Ein Wörterbuch nach Anführungen im S4KD. PW			PW
+Bibl.ind.	BIBLIND	abbrev	Bibliotheca indica	0				
+Bibliotheca sanscrita	BIBLIOTHECASANSCRITA	work		1	Von Johannes Gildemeister, Bonn, 1847. PW, pw			PW,pw
+Bi1g4ag.	BIGAG	xref	Bi1jagan2ita	0				
+Bi1jagan2ita	BIJAGANITA	xref	Li1la1vati1	0				
+Böhtlingk, Sanskrit Chresthomathie	BHTLINGKSANSKRITCHRESTHOMATHIE	xref	Sanrkrit Chresthomathie	0				
+Bra1hmabindu1p.	BRAHMABINDUP	xref	Bra1hmabindu1panis2ad	0				
+Bra1hmabindu1panis2ad	BRAHMABINDUPANISAD	xref	Atharvan2a Upanis2ads	0				
+Bra1hman.	BRAHMAN	xref	Bra1hman2avila1pa	0				
+Bra1hman2avila1pa	BRAHMANAVILAPA	xref	Indraloka1gamana	0				
+Bra1hma1n2d2a P.	BRAHMANDAP	xref	Bra1hma1n2d2a Pura1n2a	0				
+Bra1hma1n2d2a Pura1n2a	BRAHMANDAPURANA	work		1	Ohne weiteres im PW			PW
+Brahma P.	BRAHMAP	xref	Brahma Pura1n2a	0				
+Brahma Pura1n2a	BRAHMAPURANA	xref	Anthologia sanscritica [pwj20]	0				
+Brahma S.	BRAHMAS	xref	Brahmasu1tra	0				
+Brahmasu1tra	BRAHMASUTRA	work		1	Von Ba1dara1yana. 1. s. S4am2kara 2. Ed. K. M. Banerjea, Calcutta, 1870.			
+Brahma Upanis2ad	BRAHMAUPANISAD	xref	Atharvan2a Upanis2ads	0				
+Brahmav.	BRAHMAV	xref	Brahmavaivarta Pura1n2a	0				
+Brahmavaivarta Pura1n2a	BRAHMAVAIVARTAPURANA	work		1	Ohne weiteres im PW und pw.			PW
+Brahmop.	BRAHMOP	xref	Brahma Upanis2ad	0				
+Br2hada1ran2yaka Upanis2ad	BRHADARANYAKAUPANISAD	work		2	Ed. E. Röer, Calcutta, 1849-56.  PW, pw | Ed. L. Poley, Bonn, 1844.  PW	541	78	PW,PW,pw
+Br2hadd.	BRHADD	xref	Br2haddevata	0				
+Br2haddevata	BRHADDEVATA	work		1	Ein Verzeichnis von Gottheiten im R2gveda von Saunaka. PW, pw In: R. Roth:			PW,pw
+Br2haddharma P.	BRHADDHARMAP	xref	Br2haddharma Pura1n2a	0				
+Br2haddharma Pura1n2a	BRHADDHARMAPURANA	work		1	Nach Anführungen im S4KD. PW			PW
+Br2hajja1taka	BRHAJJATAKA	work		1	Ein Werk über Astrologie von Vara1hamihira. PW			PW
+Br2hanm.	BRHANM	xref	Br2hanmanu	0				
+Br2hanmanu	BRHANMANU	work		1	Nach Zitaten in verschiedenen juristischen Büchern. pw			pw
+Br2h.A1r.Up.	BRHARUP	xref	Br2hada1ran2yaka Upanis2ad	0				
+Br2hasp.	BRHASP	xref	Br2haspati	0				
+Br2haspati	BRHASPATI	work		1	Verfasser eines Gesetzbuches nach Anführungen im Mita1ks2ara und			
+Br2hatsam2hita1	BRHATSAMHITA	work		1	Ein Werk über Astrologie von Vara1hamihira. PW			PW
+Br2h.Dev.	BRHDEV	xref	Br2haddevata	0				
+Buddhokt.	BUDDHOKT	xref	Buddhoktasam2sa1ra1maya	0				
+Buddhoktasam2sa1ra1maya	BUDDHOKTASAMSARAMAYA	work		1	Handschrift in der Pariser Bibliothek. Nach Schiefner. PW			PW
+Bühler, G.	BHLERG	work		0				
+Bühler, Guj.	BHLERGUJ	work		0				
+Bühler, Rep.	BHLERREP	xref	Bühler. G.	0				
+Bull. hist. phil.	BULLHISTPHIL	abbrev	Bulletin historicophilologique de l'Acade4mie	0				
+Burnell, T.	BURNELLT	work		0				
+Burn. Intr.	BURNINTR	xref	Introduction	0				
+Burn. Lot. de la b.L.	BURNLOTDELABL	xref	Le Lotus	0				
+Bydragen	BYDRAGEN	work		0				
+c11	C	abbrev	s4es4a	0				
+C11abdak4.	CABDAK	xref	S4abdacandrika1	0				
+C11abdam.	CABDAM	xref	Sabdama1la1	0				
+C11abdar.	CABDAR	xref	Sabdaratna1vali1	0				
+C11abda1rn2.	CABDARN	xref	Sabda1rn2ava	0				
+Caitanyacandrodaya	CAITANYACANDRODAYA	work		1	Ed. R. Mitra, Calcutta, 1854.  pw	574		pw
+C11a1k.	CAK	xref	S4a1kuntala	0				
+Cakradatta	CAKRADATTA	work		1	Ein Kommentator von Caraka und Sus4ruta. Handschrift. pw			pw
+C11am2k.	CAMK	xref	S4am2kara	0				
+C11am2kar.	CAMKAR	xref	S4am2kara	0				
+C11am2k. Vig4.	CAMKVIG	xref	S4am2karavijaya	0				
+Campaka	CAMPAKA	work		1	Ed. A. Weber, Berlin, 1883. pw In: Sitzungsberichte der königlich			pw
+Ca1nakhya	CANAKHYA	xref	Ka1vyasam2graha	0				
+C11a1n2d2.	CAND	xref	S4a1n2d2ilya	0				
+Candra1loka	CANDRALOKA	work		1	Ohne weiteres im pw.			pw
+C11a1n4kh.Br.	CANKHBR	xref	S4a1n3kha1yana Bra1hman2a	0				
+C11a1n3kh. C11r.	CANKHCR	xref	S4a1n3kha1yana S4rautasu1tra	0				
+C11a1n3kha. Gr2hjj.	CANKHAGRHJJ	xref	S4a1n3kha1yana Gr2hyasu1tra	0				
+C11a1nt.	CANT	xref	S4a1ntanava	0				
+C11a1ntic11.	CANTIC	xref	S4a1ntis4ataka [pwj22]	0				
+Cantor	CANTOR	xref	Geschichte der Mathemathik	0				
+Carakasm2hita1	CARAKASMHITA	work		1	Ed. J. Vidya1sa1gara, Calcutta, 1877.  pw	611		pw
+C11a1ri3g. Paddh.	CARIGPADDH	xref	S4a1rn3gadhara Paddhati	0				
+C11a1rn3g. Sam2.	CARNGSAM	xref	S4a9rn3gadhara Sam2hita1	0				
+Ca1taka	CATAKA	work		1	Gedicht vom Vogel Ca1taka in der Zeitschrift für die Kunde des			
+Cat. All.	CATALL	xref	Cudh	0				
+C11atar. Up.	CATARUP	xref	S4atarudri1ya Upanis2ad	0				
+C11at. Br.	CATBR	xref	S4atapatha Bra1hman2a	0				
+Cat. C. Pr.	CATCPR	xref	Kielhorn	0				
+Cat. Gujar.	CATGUJAR	xref	Bühler, Guj.	0				
+Cat. Kielh.	CATKIELH	xref	Kielhorn	0				
+Cat. NW. Pr.	CATNWPR	xref	North Western Provinces	0				
+C11atr.	CATR	xref	S4atrum2jayamaha1tmya	0				
+Caturadha1yika1	CATURADHAYIKA	work		1	Von S4aunaka. Ohne weiteres im PW.			PW
+Caturbhuja	CATURBHUJA	work		1	Ein Scholiast des Maha1bha1rata. PW			PW
+Caturvargacinta1man2i1	CATURVARGACINTAMANI	work		1	Von Hemadri. Ed. Bh. S4iroman2i, Calcutta, 1873-79.  pw	630		pw
+Cat. willmot	CATWILLMOT	xref	Willmot	0				
+C11aun. K4at.	CAUNKAT	xref	Caturadhya1yika1	0				
+Caurapan5ca1s4ika1	CAURAPANCASIKA	work		2	1. s. Bhartr2hari | 2. Ed. M. Ariel, Journal asiatique, 4me Se4rie, Bd. 11, S. 469, pw			pw
+Cha1ndogyaparis4is2t2a	CHANDOGYAPARISISTA	work		1	Nach Zitaten in anderen Werken. pw			pw
+Cha1ndogya Upanis2ad	CHANDOGYAUPANISAD	xref	Taittiri1ya Upanis2ad	0				
+Chandoman5jari1	CHANDOMANJARI	work		1	Ed. Brockhaus. In: Berichte über die Verhandlungen der königlich			
+Childers R.C.	CHILDERSRC	work		0				
+Chr.	CHR	xref	Sanskrit Chresthomathie	0				
+C11ic11.	CIC	xref	S4is4upa1lavadha	0				
+C11iv.	CIV	xref	S4ivana1masahasra [pwj23]	0				
+C11KDr.	CKDR	abbrev	S4abdakalpadruma	0				
+c11l.	CL	abbrev	Sloka	0				
+C11obh.	COBH	xref	S4obhanastuti	0				
+Colebr.	COLEBR	xref	Algebra und Miscellaneous Essays	0				
+Commentary	COMMENTARY	work		0				
+Commentatio	COMMENTATIO	work		0				
+Corapan5ca1s4at	CORAPANCASAT	xref	Caurapan5ca1s4ika1	0				
+Cr11a1ddhaviv.	CRADDHAVIV	xref	S4ra1ddhaviveka	0				
+C11ri1dhar.	CRIDHAR	xref	S4ri1dharasva1min	0				
+C11r1i1p.	CRIP	xref	S4ri1patti	0				
+C11r2n4ga1rat.	CRNGARAT	xref	S4r2n4ga1ratilaka	0				
+C11rut.	CRUT	xref	S4rutabodha	0				
+C11uk. oder C11ukas.	CUKODERCUKAS	xref	S4ukasaptati	0				
+C11ukran.	CUKRAN	xref	S4ukrani1ti	0				
+C11ulbas.	CULBAS	xref	S4ulvasu1tra	0				
+Cu1lika Upanis2ad	CULIKAUPANISAD	xref	Atharvan2a Upanis2ads	0				
+Cunningham Arch Survey	CUNNINGHAMARCHSURVEY	xref	Archeological Survey	0				
+C11veta1c11v. Up.	CVETACVUP	xref	S4veta1s4vatara Upanis2ad	0				
+Dac11.	DAC	xref	Da1s4arathas Tod	0				
+Dac11abh.	DACABH	xref	Das4abhumi1s4vara	0				
+Dac11ack.	DACACK	xref	Das4akuma1racarita	0				
+Daivatabra1hman2a	DAIVATABRAHMANA	work		2	1. Ed. S. S4a1masva1mi, Calcutta, 1875. 1876.  pw | 2. Ed.  s. Daivatabra1hman2a	674		pw
+Daiv Br.	DAIVBR	xref	Daivatabra1hman2a	0				
+Da1j. oder Da1jabh.	DAJODERDAJABH	xref	Da1yabha1ga	0				
+Damayanti1katha1	DAMAYANTIKATHA	work		1	Handschrift. pw			pw
+Darpadalana	DARPADALANA	work		1	Von Ks2emendra. Handschrift. pw			pw
+Das4abhu1mi1s4vara	DASABHUMISVARA	work		1	Handschrift in der Pariser Bibliothek. Nach A. Schiefner. PW			PW
+Das4akuma1racarita	DASAKUMARACARITA	work		3	1. Ed. H. H. Wilson, Berlin, 1846.  PW | 2. Ed. M. R. Kale, Bombay, 1925. (?)  pw | 3. Ed. G. Bühler, Bombay, 1887. 1891.  pw	692,691	236	PW,pw
+Das4arathas Tod	DASARATHASTOD	xref	Sanskrit Chresthomathie	0				
+Das4aru1pa	DASARUPA	work		1	Ed. F. E. hall, Calcutta, 1865.  pw	698		pw
+Dattaka Mi1ma1m2sa1	DATTAKAMIMAMSA	work		1	Ed. J. C. C. Sutherland, Calcutta, 1817.  PW Mit		349	PW
+Datt. Mi1m.	DATTMIM	xref	Dattaka Mi1ma1m2sa1	0				
+Dattakas4iroman2i1	DATTAKASIROMANI	work		1	Ed. Bh. S4iroman2i1, Calcutta, 1867.  pw	707		pw
+Da1yabha1ga	DAYABHAGA	work		1	Ed. K. Tarka1lam2ka1ra, Calcutta, 1829.  PW, pw	714		PW,pw
+Dec11in.	DECIN	xref	Des4i1na1mama1la1	0				
+Des4i1na1mama1la1	DESINAMAMALA	work		1	Ein Lexikon über Des4iformen im Prakrit von Hemacandra. Handschrift. pw			pw
+Dev.	DEV	xref	Devi1ma1ha1tmya	0				
+Devala	DEVALA	work		1	Nach Zitaten in verschiedenen juristischen Büchern. pw			pw
+Devata1dhj. Bra1hm.	DEVATADHJBRAHM	xref	Daivatabra1hman2a	0				
+Devi1bh1gavata1 Pua1n2a	DEVIBHGAVATAPUANA	work		1	Handschrift. pw			pw
+Devi1ma1ha1tmya	DEVIMAHATMYA	work		1	Ed. L. Poley, Berlin, 1831.  PW		130	PW
+Devi1 P.	DEVIP	xref	Devi1 Pura1n2a	0				
+Devi1 Pura1n2a	DEVIPURANA	work		1	Nach Anführungen im S4KD. pw			pw
+Dhammp.	DHAMMP	xref	Dhammapada	0				
+Dhammapada	DHAMMAPADA	work		1	Ed. V. Fausböll, Kopenhagen, 1855. pw			pw
+Dhanam2jayavijaya	DHANAMJAYAVIJAYA	work		1	Ed. T. Tarkava1caspati, Calcutta, 1871.  pw	752		pw
+Dhanv.	DHANV	xref	Dhanvantaris Wörterbuch	0				
+Dhanvantaris Wörterbuch	DHANVANTARISWRTERBUCH	work		1	Handschrift, pw			pw
+Dhar.	DHAR	xref	Dharan2i1kos4a	0				
+Dharan2i1kos4a	DHARANIKOSA	work		1	Ein Wörterbuch, angeführt im S4KD. PW			PW
+Dharmas4a1stra	DHARMASASTRA	work		1	Die Darstellung der Lehre von den Schriften in Br2haspatis Dharmas4a1stra.			
+Dha1tup.	DHATUP	xref	Dha1tupa1tha	0				
+Dha1tupa1tha	DHATUPATHA	xref	Radices	0				
+Dhu1rtan.	DHURTAN	xref	Dhu1rtanartaka	0				
+Dhu1rtanartaka	DHURTANARTAKA	work		1	Handschrift. pw			pw
+Dhu1rtas.	DHURTAS	xref	Dhu1rtasama1gama	0				
+Dhu1rtasama1gama	DHURTASAMAGAMA	xref	Anthologia sanscritica	0				
+Dh. V.	DHV	xref	Dhanam2jayavijaya	0				
+Dhya1navindu1panis2ad	DHYANAVINDUPANISAD	xref	Atharvan2a Upanis2ads	0				
+Divja1v.	DIVJAV	xref	Divya1vada1na	0				
+Divya1vada1na	DIVYAVADANA	work		1	Handschrift. PW, pw			PW,pw
+Donner, Pin2d2.	DONNERPIND	xref	Pin2d2apitr2yajn5a	0				
+Dra1hya1yana	DRAHYAYANA	work		1	Verfasser eines S4rautasu1tras. PW			PW
+Draup.	DRAUP	xref	Draupadi1prama1tha	0				
+Draupadi1prama1tha	DRAUPADIPRAMATHA	xref	Arjunasama1gama	0				
+Dravyas4uddhitattva	DRAVYASUDDHITATTVA	work		1	Handschrift. pw			pw
+Durgad.	DURGAD	xref	Durgada1sa	0				
+Durgada1sa	DURGADASA	work		1	Ohne weiteres im PW.			PW
+Durga1rcatattva	DURGARCATATTVA	work		1	Nach Anführungen im S4KD. PW			PW
+Durga1rk4at.	DURGARKAT	xref	Durga1rcatattva	0				
+Dviru1pak.	DVIRUPAK	xref	Dviru1pakos4a	0				
+Dviru1pakos4a	DVIRUPAKOSA	work		1	Eine Wortsammlung, nach Anführungen im S4KD. PW			PW
+Dvived.	DVIVED	xref	Dvivedagan3ga	0				
+Dvivedagan3ga	DVIVEDAGANGA	work		1	Ein Scholiast des Ma1dhyam2dina A1ran2yaka. PW			PW
+Eitel, Chin. B.	EITELCHINB	work		1	Handbook forthe Student of Chinese Buddhism. Von E. J. Eitel, London			
+Flora indica	FLORAINDICA	work		1	, or the Description of Indian Plants. Von W. Roxburg, Serampore, 1932.			
+Führer, Br2h.	FHRERBRH	xref	Dharmas4a1stra	0				
+G4a1b. Up.	GABUP	xref	Ja1ba1la Upanis2ad	0				
+G4aim.	GAIM	xref	Jaimini	0				
+Gal.	GAL	xref	Galanos	0				
+Galanos	GALANOS	work		0				
+ganapa1tha	GANAPATHA	xref	Pa1n2ini	0				
+Ganar.	GANAR	xref	Ganaratnamahodadhi	0				
+Ganaratnamahodadhi	GANARATNAMAHODADHI	work		1	1. s. Pa1n2ini || 2. Ed. J. Eggeling, London, 1879.  pw	851		pw
+Gan2ita	GANITA	work		0				
+Garbha Upanis2ad	GARBHAUPANISAD	xref	Atharvan2a upanis2ads	0				
+Garbhop.	GARBHOP	xref	Garbha Upanis2ad	0				
+Ga1ruda Upanis2ad	GARUDAUPANISAD	xref	Atharvan2a Upanis2ads	0				
+Ga1r. Up.	GARUP	xref	Ga1ruda Upanis2ad	0				
+G4ata1dh.	GATADH	xref	Jata1dhara	0				
+Gaudap.	GAUDAP	xref	Gaudapa1da	0				
+Gaudapa1da	GAUDAPADA	work		2	1. Ein Scholiast zur Sa1m2khya Ka1rika1. PW, pw | 2. Ein Scholiast zur Ma1n2d2u1kya Upanis2ad. PW			PW,PW,pw
+Gaut.	GAUT	xref	Gautamadharmas4a1stra	0				
+Gautamadharmas4a1stra	GAUTAMADHARMASASTRA	work		1	Ed. A. F. Stenzler, London, 1876.  pw	893		pw
+Gel. Anzz. d.k.b.Ak.d.Ww.	GELANZZDKBAKDWW	abbrev	Gelehrte Anzeigen der königlich	0				
+Geschichte der Mathemathik	GESCHICHTEDERMATHEMATHIK	work		1	Von M. B. Cantor, Heidelberg, 1880-1908. pw			pw
+Geschichte des Buddhismus	GESCHICHTEDESBUDDHISMUS	work		1	Von Ta1rana1tha. Aus dem Tibetischen übersetzt von A. Schiefner. pw			pw
+Geschichte des Vidu1s2aka	GESCHICHTEDESVIDUSAKA	xref	Sanskrit Chresthomathie	0				
+Ghat2.	GHAT	xref	Ghat2akarpara [pwj27]	0				
+Ghat2akarpara	GHATAKARPARA	xref	Amarus4ataka	0				
+Gild. Bibl.	GILDBIBL	xref	Bibliotheca sanscrita	0				
+Gild. Scriptorum Arabum	GILDSCRIPTORUMARABUM	xref	Scriptorum Arabum	0				
+Gi1t.	GIT	xref	Gi1tagovinda	0				
+Gi1tagovinda	GITAGOVINDA	work		1	Ed. Chr. Lassen, Bonn, 1836.  PW, pw	912		PW,pw
+G4jot.	GJOT	xref	Jyotis2am	0				
+G4jotishat.	GJOTISHAT	xref	Jyotis2atattva	0				
+Gobh.	GOBH	xref	Gobhile Gr2hyasu1tra	0				
+Gobh. C11ra1ddhak.	GOBHCRADDHAK	xref	Gobhilagr2hyasu1tra	0				
+Gohilagr2hyasu1tra	GOHILAGRHYASUTRA	work		2	1. Nach Mitteilungen von A. Weber. PW | 2. Ed. Tarka1lam2ka1ra, Calcutta, 1871-80.  pw Mit	924		PW,pw
+Gola1dhj.	GOLADHJ	xref	Gola1dhya1ya	0				
+Gola1dhya1ya	GOLADHYAYA	xref	Siddha1ntas4iroman2i	0				
+Gold.	GOLD	xref	Goldstückers Wörterbuch	0				
+Goldstückers Wörterbuch	GOLDSTCKERSWRTERBUCH	work		0				
+Gopathabra1hman2a	GOPATHABRAHMANA	work		1	Ed. R. Mitra, H. Vidya1bhu1s2an2a, Calcutta, 1872.  pw	943		pw
+Gop. Br.	GOPBR	xref	Gopathabra1hman2a	0				
+Gorr.	GORR	xref	Gorresio	0				
+Gorresio	GORRESIO	xref	Ra1ma1yan2a	0				
+Gotama	GOTAMA	xref	Nya1ya	0				
+Got. S.	GOTS	xref	Nya1yasu1tra	0				
+Govardh.	GOVARDH	xref	Govardhana	0				
+Govardhana	GOVARDHANA	xref	Saptas4ati	0				
+Govindabh.	GOVINDABH	xref	Govindabhat2t2a	0				
+Govindabhat2t2a	GOVINDABHATTA	work		1	Ohne weiteres im PW.			PW
+Govinda1n.	GOVINDAN	xref	Govinda1nanda	0				
+Govinda1nanda	GOVINDANANDA	work		1	Glossator zu S4am2karas Kommentar zu Ba1dara1yan2a. pw			pw
+Gr2hjas.	GRHJAS	xref	Gr2hysam2graha	0				
+Gr2hjasam2gr.	GRHJASAMGR	xref	Gr2hyasam2grahaparis4is2t2a	0				
+Gr2hyasam2graha	GRHYASAMGRAHA	abbrev	Gobhila Gr2hyasu1tra	0				
+Gr2hyasam2grahaparis4is2t2a	GRHYASAMGRAHAPARISISTA	work		1	Zum Gobhila Gr2hyasu1tra. Handschrift. PW			PW
+H.	H	abbrev	Hemacandra	0				
+Haeb. Anth.	HAEBANTH	xref	Haeberlins Chresthomathie (Anthologie)	0				
+Heab. Chrest.	HEABCHREST	xref	Haeberlins Chresthomathie	0				
+Haeberlins Chresthomathie	HAEBERLINSCHRESTHOMATHIE	xref	Ka1vyasam2graha	0				
+Ha1la	HALA	xref	Saptas4ataka	0				
+Ha1laj.	HALAJ	xref	Ha1la1yuddha	0				
+Ha1la1yuddha	HALAYUDDHA	work		1	Ein Lexikograph 1. Nach Anführungen im S4KD. PW 2. Ha1la1yuddhas			PW
+Ham2sa Upanis2ad	HAMSAUPANISAD	xref	Atharvan2a Upanis2ads	0				
+Ham2sop.	HAMSOP	xref	Ham2sa Upanis2ad	0				
+H.an.	HAN	xref	Aneka1rthasam2graha	0				
+Handbuch der Sanskritsprache	HANDBUCHDERSANSKRITSPRACHE	work		1	Von Theodor Benfey, Leipzig, 1853, 1954. PW 1. Vollständige Grammatik 2.			PW
+Hanumaduktara1mopanis2ad	HANUMADUKTARAMOPANISAD	xref	Atharvan2a Upanis2ads	0				
+Hanum. Up.	HANUMUP	xref	Hanumaduktara1mopanis2ad	0				
+Ha1r.	HAR	xref	Ha1ra1vali1	0				
+Ha1ra1vali1	HARAVALI	work		0				
+Harisv.	HARISV	xref	Harisva1min	0				
+Harisva1min	HARISVAMIN	work		1	Ein Scholiast des S4atapathabra1hman2a. PW, pw			PW,pw
+Hariv.	HARIV	xref	Harisvam2s4a	0				
+Harivam2s4a	HARIVAMSA	work		1	1. Ed. M. A. Langlois, London, 1834. 1835.  PW, pw 2. und 3.		122	PW,pw
+Hariv. Langl.	HARIVLANGL	xref	harivam2s4a	0				
+Hars2acarita	HARSACARITA	work		1	Von Ba1na. Ed. J. Vidya1sa1gara, Calcutta, 1876.  pw	1042		pw
+Harshak4.	HARSHAK	xref	Hars2acarita	0				
+Ha1sj.	HASJ	xref	Ha1sya1rn2ava	0				
+Ha1sya1rn2ava	HASYARNAVA	work		2	1. Handschrift. pw | 2. Ed. C. Cappeller, Jena, 1883.  pw	1049		pw
+Haug.	HAUG	work		1	Uber das Wesen und den Wert des vedischen Akzentes, München, 1874. pw			pw
+Haughton	HAUGHTON	work		0				
+H. c11.	HC	abbrev	S4es4as in Hemacandras Abhidha1nacinta1man2i1, Seite	0				
+Hemacandra	HEMACANDRA	xref	Abhidha1nacinta1man2i1 und Aneka1rthasam2graha	0				
+Hemacandras Prakrit Grammtik	HEMACANDRASPRAKRITGRAMMTIK	work		2	1. Ed. Bombay, 1872.  pw | 2. Ed. R. Pischel. Halle, 1877, 1880.  pw	1938,1938		pw
+Hemacandras Yogas4a1stra	HEMACANDRASYOGASASTRA	xref	Yogas4a1stra	0				
+Hema1dri	HEMADRI	xref	Caturvargacinta1man2i1	0				
+Hem. Jog.	HEMJOG	xref	Yogas4a1stra	0				
+Hem. Par.	HEMPAR	xref	Paris4is2t2aparvan	0				
+Hem. Pr. Gr.	HEMPRGR	xref	Hemacandras Prakrit Grammatik	0				
+Hessler	HESSLER	xref	Sus4ruta	0				
+Hid.	HID	xref	Hidimbavadha	0				
+Hidimbavadha	HIDIMBAVADHA	xref	Indraloka1gamana	0				
+Hillebrandt	HILLEBRANDT	work		0				
+Hindu Th. (Wilson)	HINDUTHWILSON	xref	Wilson	0				
+Hiouen Thsang	HIOUENTHSANG	work		1	1. Histoire de la vie de Hiouen Thsang et de ses voyages			
+Hit.	HIT	abbrev	Hitopades4a	0				
+Hit. ed. Johns.	HITEDJOHNS	xref	Hitopades4a	0				
+Hitopades4a	HITOPADESA	work		2	1. Ed. Schlegel und Lassen, Bonn, 1829.  PW, pw | 2. Ed. F. Johnson, London, 1847-48.  pw	1070	225	PW,pw,pw
+Hit. Pr.	HITPR	abbrev	Prooemium zum Hitopades4a	0				
+Hora1c11.	HORAC	xref	Hora1s4a1stra	0				
+Hora1s4a1stra	HORASASTRA	work		1	Ohne weiteres im PW.			PW
+Hort. beng.	HORTBENG	xref	Hortus bengalensis	0				
+Hort. calc.	HORTCALC	xref	Hortus suburbanus calcuttensis	0				
+Hortus bengalensis	HORTUSBENGALENSIS	work		1	Zitiert nach haughtons Wörterbuch. PW			PW
+Hortus subrubanus calcuttensis	HORTUSSUBRUBANUSCALCUTTENSIS	work		1	A Catalogue of Plants. Von J. O. Voigt, Calcutta, 1845. PW			PW
+I1c11op.	ICOP	xref	I1s4a Upanis2ad	0				
+Ind. Antiq.	INDANTIQ	xref	Indian Antiquary	0				
+Ind. d. Kand4.	INDDKAND	xref	Index des Kanjur	0				
+Index des Kanjur	INDEXDESKANJUR	work		1	Ed. I. J. Schmidt, St. Petersburg, 1845. PW			PW
+India	INDIA	work		0				
+Indische Altertumskunde	INDISCHEALTERTUMSKUNDE	work		1	Von Chr. Lassen, Bonn, 1844-62. PW. pw			PW
+Indisches Erbrecht	INDISCHESERBRECHT	work		1	Von A. Mayr, Wien, 1873. pw			pw
+Indische Sprüche	INDISCHESPRCHE	work		1	Von O. Böhtlingk, St. Petersburg, 1863-65.  PW, pw	1087		PW,pw
+Indisches Schuldrecht	INDISCHESSCHULDRECHT	work		1	Von J. Jolly, Münchner philos. --phil. Abhandlungen, 1877. S. 528ff pw			pw
+Indische Streifen	INDISCHESTREIFEN	work		1	Von A. Weber, Berlin, 1868. 1869. pw			pw
+Indische Studien	INDISCHESTUDIEN	work		1	Von A. Weber, Berlin, 1855-98. PW, pw Mit: Pra1tis4a1khya zur			PW,pw
+Indr.	INDR	xref	Indraloka1gamana	0				
+Indraloka1gamana	INDRALOKAGAMANA	work		0				
+Ind. St.	INDST	xref	Indische Studien	0				
+Ind. Str.	INDSTR	xref	Indische Streifen	0				
+Institutiones Linguae Pracriticae	INSTITUTIONESLINGUAEPRACRITICAE	work		1	Von Chr. Lassen, Bonn, 1837. PW			PW
+Institt. (Lassen)	INSTITTLASSEN	xref	Institutiones Linguae Pracriticae	0				
+Introduction a l'histoire indienne	INTRODUCTIONALHISTOIREINDIENNE	work		1	Von M. E. Burnouf, Paris, 1844. PW, pw			PW,pw
+I1s4a Upanis2ad	ISAUPANISAD	xref	Taittiri1ya Upanis2ad	0				
+Itih.	ITIH	abbrev	Itiha1sa	0				
+Ja1ba1la Upanis2ad	JABALAUPANISAD	xref	Atharvan2a Upanis2ads	0				
+Ja1g4n4.	JAGN	xref	Ya1jn5avalkya [pwj31]	0				
+Ja1g4n4ad. (Lois. )	JAGNADLOIS	xref	Ya1jn5adattavadha	0				
+Ja1g4n4ikad. Paddh. zu Ka1tj. C11r.	JAGNIKADPADDHZUKATJCR	xref	Ya1jn5ikadevas Paddhati	0				
+Jag4. V.	JAGV	xref	Yajurveda	0				
+Jaimini	JAIMINI	xref	Mi1ma1m2sa1	0				
+Jaimini1yanya1yama1la1vista1ra	JAIMINIYANYAYAMALAVISTARA	work		1	Ed. Th. Goldstücker, E. B. Cowell, London, 1878.  pw	1621		pw
+J. A. O. S.	JAOS	abbrev	Journal of the American Orientel Society. pw	0				
+J. A. S. Beng.	JASBENG	abbrev	Journal of the Asiatic Society of Bengal. pw	0				
+Jata1dhara	JATADHARA	work		1	Ein Lexikograph, angeführt im S4KD. PW, pw			PW,pw
+Ja1takama1la1	JATAKAMALA	work		1	Ohne weiteres im pw.			pw
+Javanec11.	JAVANEC	xref	Yavanes4vara	0				
+Jogac11. Up.	JOGACUP	xref	Yogas4ikha Upanis2ad	0				
+Jogas.	JOGAS	xref	Yogasu1tra	0				
+Jogat. Up.	JOGATUP	xref	Yogatattva Upanis2ad	0				
+Jolly	JOLLY	xref	Indisches Schuldrecht	0				
+Journ. as.	JOURNAS	abbrev	Journal Asiatique	0				
+Journ. of the Am. Or. S.	JOURNOFTHEAMORS	abbrev	Journal of the American Oriental Society.	0				
+J.R.A.A.	JRAA	abbrev	Journal of the Royal Asiatic Society	0				
+Jyotis2am	JYOTISAM	work		1	Uber den Vedakalender namens Jyotis2am. Von A. Weber, Berlin, 1862. pw			pw
+Jyotis2a zum Atharvaveda	JYOTISAZUMATHARVAVEDA	work		1	Handschrift. pw			pw
+Jyotis2atattva	JYOTISATATTVA	work		1	Nach Anführungen im S4KD. PW			PW
+Ka1c11.	KAC	xref	Ka1s4ika1 Vr2tti	0				
+Ka1d. oder Ka1damb.	KADODERKADAMB	xref	Ka1dambari	0				
+Ka1dambari1	KADAMBARI	work		2	1. Handschrift. PW | 2. Ed. Calcutta, 1852.  pw	1203		PW,pw
+Kaij.	KAIJ	xref	Kaiyata	0				
+K4aitanj.	KAITANJ	xref	Caitanyacandrodaya	0				
+Kaivaljob.	KAIVALJOB	xref	Kaivalya Upanis2ad	0				
+Kaivalya Upanis2ad	KAIVALYAUPANISAD	xref	Atharvan2a Upanis2ads	0				
+Kaiv. Up.	KAIVUP	xref	Kaivalya Upanis2ad [pwj32]	0				
+Kaiyata	KAIYATA	work		1	Ein Kommentator zum Maha1bha1s2ya. PW			PW
+K4akr.	KAKR	xref	Cakradatta	0				
+Ka1lacakra	KALACAKRA	work		1	Handschrift. pw			pw
+Ka1lak4.	KALAK	xref	Ka1lacakra	0				
+Ka1lanirn2aya	KALANIRNAYA	work		1	Von Ma1dhava. Ohne weiteres im pw.			pw
+Ka1lasam2kalita1	KALASAMKALITA	work		1	Zitiert nach Haughtons Wörterbuch. PW			PW
+Ka1lid.	KALID	abbrev	Ka1lida1sa	0				
+Ka1lika P.	KALIKAP	xref	Ka1lika Pura1n2a	0				
+Ka1lika1 Pura1n2a	KALIKAPURANA	work		1	Nach Anführungen im S4KD. PW			PW
+Kalpadruma1v.	KALPADRUMAV	xref	Kalpadruma1vada1na	0				
+Kalpadruma1vada1na	KALPADRUMAVADANA	work		1	Handschrift in der Pariser Bibliothek. Nach Schiefner. PW			PW
+Kalpas.	KALPAS	xref	Kalpasu1tra	0				
+Kalpasu1tra	KALPASUTRA	work		1	Von Bhadraba1hu. Ed. H. Jacobi, Leipzig, 1879.  pw	1231		pw
+Ka1mandaki1yani1tisa1ra	KAMANDAKIYANITISARA	work		1	Ed. R. Mitra, Calcutta, 1861.  pw	1861		pw
+Ka1m. Ni1tis.	KAMNITIS	xref	Ka1mandaki1yani1tisa1ra	0				
+K4a1n2:	KAN	xref	Ca1n2akhya	0				
+Kan2.	KAN	xref	Kan2a1da	0				
+Kan2a1da	KANADA	xref	Vais4es4ika	0				
+Ka1n2d2.	KAND	xref	Ka1n2d2u1pa1khya1na	0				
+Kan2d2ak.	KANDAK	xref	Kan2d2akaus4ika1	0				
+kan2d2akaus4ika1	KANDAKAUSIKA	work		1	Von Ks2emi1s4vara. pw			pw
+Kandjur	KANDJUR	xref	Index des Kandjur	0				
+Ka1n2d2u1pa1khya1na	KANDUPAKHYANA	xref	Anthologia sanscritica	0				
+Kan2t2haer. Up.	KANTHAERUP	xref	Kan2t2has4ruti Upanis2ad	0				
+Kan2t2ahas4ruti Upanis2ad	KANTAHASRUTIUPANISAD	xref	Atharvan2a Upanis2ads	0				
+Kap.	KAP	xref	Kapila	0				
+Kap. (Ball. )	KAPBALL	xref	Kapila	0				
+Ka1pi1c11.	KAPIC	xref	Ka1pi1s4a1vada1na	0				
+Kapila	KAPILA	xref	Sa1m2khya [pwj33]	0				
+Ka1pi1s4a1vada1na	KAPISAVADANA	work		1	Handschrift in der Pariser Bibliotherk. Nach Schiefner. PW			PW
+Kapis2t2halakatha1sam2hita1	KAPISTHALAKATHASAMHITA	work		1	Handschrift. pw			pw
+Kap.	KAP	xref	Kapis2t2halakatha1sam2hita1	0				
+Ka1r.	KAR	xref	Ka1rika1	0				
+Ka1ran2d2.	KARAND	xref	Ka1ran2d2avyu1ha	0				
+Ka1ran2d2avyu1ha	KARANDAVYUHA	work		1	Ed. S. S4a1masva1mi, Calcutta, 1873.  pw	1972		pw
+Ka1rika1	KARIKA	work		1	Ohne weiteres im PW und pw.			PW
+Karmapr.	KARMAPR	xref	Karmpradi1pa	0				
+Karmapradi1pa	KARMAPRADIPA	work		1	Steht unter dem Falschen Titel Ka1tja1jana Smr2ti im			
+Ka1s4ika1 Vr2tti	KASIKAVRTTI	work		1	In der Zeitschrift "The Pandit", 7 fgg und in Böhtlingks Einleitung zum			
+Ka1s4ikhan2d2a	KASIKHANDA	work		1	Handschrift. pw			pw
+Ka1t.	KAT	xref	Ka1tavema	0				
+Ka1t.	KAT	xref	Ka1tantra	0				
+K4a1t.	KAT	xref	Ca1taka	0				
+Ka1tantra	KATANTRA	work		1	Ed. J. Eggeling, Calcutta, 1874.  pw	1282		pw
+Ka1tavema	KATAVEMA	work		1	Ein Scholiast des S4a1kuntala. PW			PW
+Ka1thaka.	KATHAKA	work		1	Eine Rezension des weissen Yajurveda. Handschrift. PW. pw			PW
+Ka1thakagr2hyasu1tra	KATHAKAGRHYASUTRA	work		1	Handschrift. pw			pw
+Ka1tha1rn2ava	KATHARNAVA	work		1	Handschrift. pw			pw
+Katha1s.	KATHAS	xref	katha1saritsa1gara	0				
+Katha1saritsa1gara	KATHASARITSAGARA	work		1	Ed. Brokhaus, Leipzig, 1839-43.  PW, pw	1288		PW,pw
+Kat2ha Upanis2ad	KATHAUPANISAD	xref	Taittiri1ya Upanis2ad	0				
+Ka1th.Gr2hj.	KATHGRHJ	xref	Ka1thaka Gr2hyasu1tra	0				
+Kathina1vada1na	KATHINAVADANA	work		1	Handshrift nach Schiefner. PW			PW
+Kat2hop.	KATHOP	xref	Kat2ha Upanis2ad	0				
+Ka1tj.	KATJ	xref	Ka1tya1yana	0				
+Ka1tj. C11ra1ddhak.	KATJCRADDHAK	xref	Ka1tya1yana S4ra1ddhakalpasu1tra	0				
+Ka1tj. Dh.	KATJDH	xref	Ka1tya1yana Dharmasu1tra	0				
+Ka1tj. Paddh.	KATJPADDH	xref	Ka1tya1yana S4rautasu1tra	0				
+K4aturbh.	KATURBH	xref	Caturbhuja	0				
+Ka1tya1yana Dharmasu1tra	KATYAYANADHARMASUTRA	work		1	Ohne weiteres im pw.			pw
+Ka1tya1yana Sna1nasu1tra	KATYAYANASNANASUTRA	work		1	Ohne weiteres im pw.			pw
+Ka1tya1yana S4ra1ddhakalpasu1tra	KATYAYANASRADDHAKALPASUTRA	work		1	Ohne weiteres im pw.			pw
+Ka1tya1yana S4rautasu1tra	KATYAYANASRAUTASUTRA	xref	Yajurveda	0				
+Kauc11.	KAUC	xref	Kaus4ikasu1tra	0				
+K4aurap.	KAURAP	xref	Caurapan5ca1s4ikha1	0				
+Kaush. A1r.	KAUSHAR	xref	Kaus4i1taki1 A1ran2yaka	0				
+Kaush. Br.	KAUSHBR	xref	Kaus4i1taki1 Bra1hman2a	0				
+Kaush. Up.	KAUSHUP	xref	Kaus4i1taki1 Bra1hman2a Upanis2ad	0				
+Kaus4ikasu1tra	KAUSIKASUTRA	work		1	Zum Atharvaveda. Handschrift. PW, pw			PW,pw
+Kaus4i1taki1 A1ran2yaka	KAUSITAKIARANYAKA	work		1	Ohne weiteres im pw.			pw
+Kaus4i1taki1 Bra1hman2a	KAUSITAKIBRAHMANA	work		1	Ohne weiteres im PW.			PW
+Kaus4i1taki1 Bra1hman2a Upanis2ad	KAUSITAKIBRAHMANAUPANISAD	xref	Atharvan2a Upanis2ads	0				
+Kautukar.	KAUTUKAR	xref	Kautukaratna1kara	0				
+Kautukaratna1kara	KAUTUKARATNAKARA	work		1	Handschrift. pw			pw
+Kavikalpadr.	KAVIKALPADR	xref	Kavikalpadruma	0				
+Kavikalpadruma	KAVIKALPADRUMA	work		1	Eine Wortsammlung, Angeführt im S4KD. PW			PW
+Kavikan2t2ha1bharan2a	KAVIKANTHABHARANA	work		1	Von Ks2emendra. Ed. J. Schönberg, Wien, 1884.  pw	1308		pw
+Ka1vjak4.	KAVJAK	xref	Ka1vyacandrika1	0				
+Ka1vjapr.	KAVJAPR	xref	Ka1vyapraka1s4a	0				
+Ka1vyacandrika1	KAVYACANDRIKA	work		1	Ein Lehrbuch der Rhetorik, nach Anführungen im S4KD. PW			PW
+Ka1vya1lm2ka1ra	KAVYALMKARA	work		1	Von Va1mana. Mit Vr2tti. Ed. C. Cappeller, Jena, 1875.  pw	1316		pw
+Ka1vyalokalocana	KAVYALOKALOCANA	work		1	Handschrift. pw			pw
+Ka1vyapraka1s4a	KAVYAPRAKASA	work		1	Ed. Calcutta, 1829.  PW, pw		265	PW,pw
+Ka1vyasam2graha	KAVYASAMGRAHA	work		1	A Sanscrit Anthology. Von J. Haeberlin, Calcutta, 1847. PW, pw Mit:			PW,pw
+Kena Upanis2ad	KENAUPANISAD	xref	Taittiri1ya Upanis2ad	0				
+Kenop.	KENOP	xref	Kena Upanis2ad	0				
+Khan2d2apras4asti	KHANDAPRASASTI	work		1	Im Pandit: Band 5 und 6. pw			pw
+K4han2d2om.	KHANDOM	xref	Chan2d2oman5jari1	0				
+K4ha1nd. Up.	KHANDUP	xref	Cha1ndogya Upanis2ad	0				
+Kielhorn	KIELHORN	work		0				
+Kir.	KIR	xref	Kira1ta1rjuni1ya	0				
+Kira1ta1rjuni1ya	KIRATARJUNIYA	work		1	Ed. Calcutta, 1814.  PW, pw		139	PW,pw
+Kopenhagen	KOPENHAGEN	work		1	Verzeichnis der Kopenhagener Sanskrit Handschriften Von Westergaard. pw			pw
+Kos.	KOS	xref	Kosegarten	0				
+Kosegarten	KOSEGARTEN	xref	Pan5catantra	0				
+Kosht2ipr.	KOSHTIPR	xref	Kos2t2ipradi1pa	0				
+Kos2t2ipradi1pa	KOSTIPRADIPA	work		1	Nach Anführungen im S4KD. PW			PW
+Kriya1sam2.	KRIYASAM	xref	Kriya1sam2uccaya	0				
+Kriya1sam2uccaya	KRIYASAMUCCAYA	work		1	Handschrift in der Pariser Bibliotherk. Nach Schiefner. PW			PW
+Kr2shis.	KRSHIS	xref	Kr2s2isam2graha	0				
+Kr2s2isam2graha	KRSISAMGRAHA	work		1	Von Paras4ara. Ed. Calcutta, 1862. pw			pw
+Kr2s2n2ajanma1s2t2ami1	KRSNAJANMASTAMI	work		1	Ed. A. Weber, pw.			pw
+Ks2emendra	KSEMENDRA	xref	Kavikan2t2ha1bharan2a	0				
+Ks2emi1s4vara	KSEMISVARA	xref	Kan2d2akaus4ika1	0				
+Kshiti1c11.	KSHITIC	xref	Ks2iti1s4avam2s4avali1carita	0				
+Kshur. Up.	KSHURUP	xref	Ks2urika Upanis2ad	0				
+Kshurikop.	KSHURIKOP	xref	Ks2urika Upanis2ad	0				
+Ks2iti1s4avam2s4avali1carita	KSITISAVAMSAVALICARITA	work		1	Ed. W. Pertsch, Berlin, 1852.  pw	1401		pw
+Ks2urika Upanis2ad	KSURIKAUPANISAD	xref	Atharvan2a Upanis2ads	0				
+Kuhn's Z.	KUHNSZ	abbrev	Zeitschrift für vergleichende Sprachforschung auf dem	0				
+Kula1rn2ava	KULARNAVA	work		1	Handschrift. pw			pw
+K4u1likop.	KULIKOP	xref	Cu1lika Upanis2ad	0				
+Kull.	KULL	xref	Kullu1ka	0				
+Kullu1ka	KULLUKA	xref	Manu	0				
+Kuma1ras.	KUMARAS	xref	Kuma1rasam2bhava	0				
+Kuma1rasam2bhava	KUMARASAMBHAVA	work		2	1. Ed. A. F. Stenzler, Berlin, 1838.  PW, pw | 2. Ed. T. Tarkava1caspati, Calcutta, 1868.  pw	1406,1408		PW,pw,pw
+Kuma1rasv.	KUMARASV	xref	Kuma1rasva1min	0				
+Kuma1rasva1min	KUMARASVAMIN	work		1	Ein Kommentator des Prata1parudri1ya. pw			pw
+Kunt.	KUNT	xref	Kunta1pa	0				
+Kunta1pa	KUNTAPA	work		1	10 Lieder, die einen besonderen Abschnitt von AV Buch 20 bilden. PW			PW
+Ku1rma P.	KURMAP	xref	Ku1rma Pura1n2a	0				
+Ku1rma Pura1n2a	KURMAPURANA	work		1	Ohne weiteres im PW.			PW
+Kusum.	KUSUM	xref	Kusuman5jali1	0				
+Kusuman5jali1	KUSUMANJALI	work		1	Von Udayana. Ed. E. B. cowell, Calcutta, 1864.  pw	1807		pw
+Kuvala1j.	KUVALAJ	xref	Kuvala1ya1nanda	0				
+Kuvalaya1nanda	KUVALAYANANDA	work		2	1. Nach 2 lithographierten Ausgaben. pw | 2. Von Appaya Di1ks2ita. Ed. Poona, 1846.  PW	1426		PW,pw
+LA.	LA	xref	Lassen	0				
+Laghug4.	LAGHUG	xref	Laghuja1taka	0				
+Laghuja1taka	LAGHUJATAKA	work		1	Von Vara1hamihira. PW, pw			PW,pw
+Laghuk.	LAGHUK	xref	Laghukaumudi1	0				
+Laghukaumudi1	LAGHUKAUMUDI	work		2	1. Ed. Calcutta, 1811.  PW | 2. Ed. Ballantyne, Benares, 1867.  pw	1437	245	PW,pw
+Lalit.	LALIT	xref	Lalitavista1ra	0				
+Lalitavista1ra	LALITAVISTARA	work		2	1. Ed. R. Mitra, Calcutta, 1853. 1877.  PW, pw | 2. Rg Tcher Rol Pa ou De4velopment des Jeux. Ed. Ph. Ed. Foucaux, Paris	1465		PW,pw
+Lassen	LASSEN	xref	Anthologia sanscritica, Indische Altertumskunde und	0				
+La1tj.	LATJ	xref	La1tya1yana S4rautasu1tra	0				
+La1tya1yana S4rautasu1tra	LATYAYANASRAUTASUTRA	work		2	1. Ed. A. Veda1ntava1gi1s4a, Calcutta, 1870-72.  pw | 2. Handschrift. PW	1468		PW,pw
+Lebens.	LEBENS	xref	Lebensbeschreibung	0				
+Lebensbeschreibung	LEBENSBESCHREIBUNG	work		0				
+Le Lotus	LELOTUS	work		0				
+Leumann	LEUMANN	xref	Aupapa1tikasu1tra	0				
+Lex. sanscr. tib.	LEXSANSCRTIB	xref	Vyutpatti	0				
+Lia.	LIA	xref	Indische Altertumskunde	0				
+Li1lia1vati1	LILIAVATI	work		1	Von Bha1skara A1cha1rya. (Bhi1jagan2ita) Ed. Calcutta, 1846.	2466		
+Lin3ga P.	LINGAP	xref	Lin3ga Pura1n2a	0				
+Lin3ga Pura1n2a	LINGAPURANA	work		1	Ohne weiteres im PW.			PW
+List of Sanscrit Manuscripts	LISTOFSANSCRITMANUSCRIPTS	xref	Oppert	0				
+Lit. (Web. )	LITWEB	xref	Akademische Vorlesungen	0				
+L.K.	LK	xref	Laghukaumudi1	0				
+Lois.	LOIS	xref	Loiseleur	0				
+Loiseleur	LOISELEUR	xref	Manu	0				
+Lot. de la b.L.	LOTDELABL	xref	Le Lotus	0				
+M.	M	xref	Ma1navadharmas4as4a1stra [pwj38]	0				
+Mac11.	MAC	xref	Mas4aka Kalpasu1tra	0				
+Madanav.	MADANAV	xref	Madanavinoda	0				
+Madanavinoda	MADANAVINODA	work		2	1. Ed. Benares, 1869. pw | 2. Handschrift. pw			pw
+Ma1dhavak.	MADHAVAK	xref	Ma1dhavaka1ra	0				
+Ma1dhavaka1ra	MADHAVAKARA	work		1	Verfasser der Rugvinis4caya. PW			PW
+Ma1dhj. Rec.	MADHJREC	xref	S4atapathavra1hman2a	0				
+Ma1dh. Ka1lan2.	MADHKALAN	xref	Ka1lanirn2aya	0				
+Madhus.	MADHUS	xref	Madhusu1dhanasarasvati	0				
+Madhusu1danasarasvati	MADHUSUDANASARASVATI	xref	Indische Studien	0				
+Ma1ga	MAGA	work		0				
+Maha1bh.	MAHABH	xref	Maha1bha1s2ya oder Maha1bha1rata	0				
+Maha1bha1rata	MAHABHARATA	work		3	1. Eine Bombayer und Calcuttaer Ausgabe. pw | 2. Ed. Calcutta, 1834-39. . PW. Mit Harivam2s9a | 3. Ed. Vardhama1na, Burdwan, 1784, 1803.  pw	1497	93	PW,pw
+Maha1bha1s2ya	MAHABHASYA	work		3	1. Eine Edition aus Benares. pw | 2. Ed. F. Kielhorn, Bombay, 1880-85.  pw | 3. Erawähnt in Böhtlingks Pa1n2ini Ausgabe. PW	185		PW,pw
+Maha1c11.	MAHAC	xref	Maha1s4a1nti	0				
+Maha1n.	MAHAN	xref	Maha1na1t2aka	0				
+Maha1na1ra1yan2a Upanis2ad	MAHANARAYANAUPANISAD	work		1	Ohne weiteres im PW.			PW
+Maha1na1r. Up.	MAHANARUP	xref	Maha1na1ra1yan2a Upanis2ad	0				
+Maha1na1t2aka	MAHANATAKA	work		1	Ed. K. Kr2s2n2a Bahadur, Calcutta, 1840.  PW		220	PW
+Maha1s4a1nti	MAHASANTI	work		1	Handschrift. pw			pw
+Maha1 Upanis2ad	MAHAUPANISAD	work		1	Ohne weiteres im PW.			PW
+Mahav.	MAHAV	xref	Mahavi1racarita	0				
+Mahavi1racarita	MAHAVIRACARITA	work		1	Ed. F. H. Tritten, London, 1848.  PW, pw	1530		PW,pw
+Mahavi1rak4.	MAHAVIRAK	xref	Mahavi1racarita	0				
+Mahi1dh.	MAHIDH	xref	Mahi1dhara [pwj39]	0				
+Maha1dhara	MAHADHARA	work		1	Ein Kommentator der Va1jasaneyisam2hita1. PW. pw			PW
+Mahop.	MAHOP	xref	Maha1 Upanis2ad	0				
+Maitra1yan2i1 Paddhati	MAITRAYANIPADDHATI	work		1	Handschrift. pw			pw
+Maitra1yan2i1 Sam2hita1	MAITRAYANISAMHITA	work		1	Ed. L. v. Schröder, Leipzig, 1881.  pw	1537		pw
+Maitra1yan2i1 Upanis2ad	MAITRAYANIUPANISAD	work		1	1. Handschrift. PW || 2. Ed. E. B. Cowell, London, 1870.  pw	1538		PW
+Maitrjup.	MAITRJUP	xref	Maitra1yan2i1 Upanis2ad	0				
+Maitr. Paddh.	MAITRPADDH	xref	Maitra1yan2i1 Paddhati	0				
+Ma1jat.	MAJAT	xref	Ma1yatantra	0				
+Malama1satattva	MALAMASATATTVA	work		1	75 Seiten. Nach Anführungen im S4KD.  PW		325	PW
+Ma1lat. oder Ma1lati1m.	MALATODERMALATIM	xref	Ma1lati1ma1dhava	0				
+Ma1lati1ma1dhava	MALATIMADHAVA	work		2	1. Ed. Calcutta, 1830.  PW, pw | 2. Ed. R. G. Bhandarkar, Bombay, 1876.  pw	1540,1541		PW,pw,pw
+Ma1lav.	MALAV	xref	Ma1lavi1ka1gnimitra	0				
+Ma1lavi1ka1gnimitra	MALAVIKAGNIMITRA	work		1	Ed. O. F. Tullberg, Bonn, 1840.  PW, pw	1541		PW,pw
+Mallin.	MALLIN	xref	Mallina1tha	0				
+Mallina1tha	MALLINATHA	work		1	Ein Kommentator des Ka9lida1sa. PW, pw			PW,pw
+Ma1navadharmas4a1stra	MANAVADHARMASASTRA	xref	Manu	0				
+Ma1navagr2hysu1tra	MANAVAGRHYSUTRA	work		1	Handschrift in der Univertitätsbibliothek Bombay. Mit Paddhati. pw			pw
+Ma1navakalasu1tra	MANAVAKALASUTRA	work		1	Ed. Th. Goldstücker, London, 1861.  PW, pw	1552		PW,pw
+Ma1nava S4rautasu1tra	MANAVASRAUTASUTRA	work		1	Handschrift. pw			pw
+Ma1n. C11r.	MANCR	xref	Ma1nava S4rautasu1tra	0				
+Ma1n2d2. C11ik2sha1	MANDCIKSHA	xref	Ma1n2d2u1ki1 S4iks2a	0				
+Ma1n2d2u1kya Upanis2ad	MANDUKYAUPANISAD	xref	Taittiri1ya Upanis2ad	0				
+Ma1n2d2u1ki1 S4iks2a	MANDUKISIKSA	work		1	Ohne weiteres im pw.			pw
+Ma1n2d2. Up.	MANDUP	xref	Ma1n2d2u1kya Upanis2ad	0				
+Ma1n2d2a. Up. Ka1r.	MANDAUPKAR	xref	Ma1n2d2u1kya Upanis2ad [pwj40]	0				
+Ma1n.Gr2hj.	MANGRHJ	xref	Ma1nava Gr2hyasu1tra	0				
+Man4g4uc11ri1n.	MANGUCRIN	xref	A1ryaman5jus4ri1namasam2gi1ti	0				
+Ma1n. K.S.	MANKS	xref	Ma1nava Kalpasu1tra	0				
+Mantrabr.	MANTRABR	xref	Mantrabra1hman2a	0				
+Mantrabra1hman2a	MANTRABRAHMANA	work		1	Vielleicht Ed. Calcutta. 1872.  pw	1574		pw
+Manu	MANU	work		0				
+Ma1rkan2d2eya Pura1n2a	MARKANDEYAPURANA	work		1	Ed. K. M. Banerjea, Calcutta, 1855. 1862.  PW, pw	1590		PW,pw
+Ma1rk. P.	MARKP	xref	Ma1rkan2d2eya Pura1n2a	0				
+Mas4aka Kalpasu1tra	MASAKAKALPASUTRA	work		1	Ohne weiteres im PW.			PW
+Materia indica	MATERIAINDICA	work		1	of the Hindus. Von U. Ch. Dutt, Calcutta, 1877. pw			pw
+Mathura1n.	MATHURAN	xref	Mathura1na1t2ha	0				
+Mathura1na1tha	MATHURANATHA	work		1	Ein Scholiast des Amarakos4a. Nach Anführungen im S4KD. PW			PW
+Mat. ind.	MATIND	xref	Materia indica	0				
+Mat. med.	MATMED	xref	Materia medica	0				
+Matsja P.	MATSJAP	xref	Matsya Pura1n2a	0				
+Matsjop.	MATSJOP	xref	Matsyopa1khya1nam	0				
+Matsya Pura1n2a	MATSYAPURANA	work		2	1. Handschrift. PW | 2. Ed. R. Jana1rdana1ca1rya, Poona, 1874. pw	1598		PW,pw
+Matsyopa1khya1nam.	MATSYOPAKHYANAM	xref	Arjunasama1gama	0				
+Ma1ya1tantra	MAYATANTRA	work		1	Nach Anführungen im S4KD. PW			PW
+Mayr	MAYR	xref	Indisches Erbrecht	0				
+Mbh.	MBH	xref	Maha1bha1rata	0				
+Med.	MED	xref	Medini1kos4a	0				
+Med. avj.	MEDAVJ	xref	Avyaya1neka1rthavarga	0				
+Medha1tithi	MEDHATITHI	work		1	Ein Scholiast des S4a1kuntala. pw			pw
+Medini1kos4a	MEDINIKOSA	xref	Ha1ra1vali	0				
+Megh.	MEGH	xref	Meghadu1ta [pwj41]	0				
+Meghadu1ta	MEGHADUTA	work		2	1. Ed. J. Gildemeister, Bonn, 1841.  PW Mit S4r2n3ga1ratilaka | 2. Ed. A. F. Stenzler, Breslau, 1874.  pw	1605	151	PW,pw
+Me4l. asiat.	MELASIAT	abbrev	Me4langes asiatiques, tire4s du Bulletin	0				
+Me4moire sur l'Inde	MEMOIRESURLINDE	work		0				
+Mi1ma1m2sa1	MIMAMSA	work		0				
+Miscellaneous Essays	MISCELLANEOUSESSAYS	work		1	Von H. T. Colebrooke, London, 1837. PW, pw			PW,pw
+Mit.	MIT	xref	Mita1ks2ara	0				
+Mita1ks2ara	MITAKSARA	work		1	Ed. L. N. Nya1ya1lam2ka1ra, Calcutta, 1829.  PW, pw	3096		PW,pw
+M.K.S.	MKS	xref	Ma1navakalpasu1tra	0				
+M. Müller, Re.	MMLLERRE	xref	India	0				
+Molesw.	MOLESW	xref	Molesworth	0				
+Molesworth	MOLESWORTH	work		0				
+Monatsberichte	MONATSBERICHTE	work		1	der königlich preussischen Aka demie der Wissenschaften in Belin. pw			pw
+Mon.d.B.A.	MONDBA	xref	Monatsberichte	0				
+Mr2cchakatika	MRCCHAKATIKA	work		1	Ed. A. F. Stenzler, Bonn, 1846.  PW, pw	1634		PW,pw
+Mr2k4k4h.	MRKKH	xref	Mr2cchakatika	0				
+Mudra1r.	MUDRAR	xref	Mudra1ra1ks2asa	0				
+Mugdhabodha	MUGDHABODHA	work		1	Von Vopadeva. Ed. O. Böhtlingk, St. Petersbourg, 1842.  PW, pw	1842		PW,pw
+Muir, J.	MUIRJ	work		0				
+Müller, SL	MLLERSL	xref	A History of Ancient Sanscrit Literature. Von Max	0				
+Mun2d2aka Upanis2ad	MUNDAKAUPANISAD	xref	Taittiri1ya Upanis2ad	0				
+Mun2d2ama1la1t.	MUNDAMALAT	xref	Mun2d2ama1la1tantra	0				
+Mun2d2ama1la1tantra	MUNDAMALATANTRA	work		1	Nach Anführungen im S4KD. PW			PW
+Mun2d2. Up.	MUNDUP	xref	Mun2d2aka Upanis2ad	0				
+N.	N	xref	Nala	0				
+Ma1dabindu1panis2ad	MADABINDUPANISAD	xref	Atharvan2a Upanis2ads	0				
+Na1dap. Up.	NADAPUP	xref	Na1dabindu1panis2ad	0				
+Na1ga1n.	NAGAN	xref	Na1ga1nanda	0				
+Na1ga1nanda	NAGANANDA	work		1	Nach zwei calcuttaer Ausgaben. pw			pw
+Naigh.	NAIGH	xref	Naighan2t2ukakha1n2d2a	0				
+Naighn2t2ukakha1n2d2a	NAIGHNTUKAKHANDA	xref	Nirukta	0				
+Nais4adacarita	NAISADACARITA	work		1	Ed. Calcutta. 1836.  PW, pw		143	PW,pw
+Naish.	NAISH	xref	Nais2adacarita	0				
+Nala	NALA	work		3	1. Ed. H. Brockhaus, Leipzig, 1859.  PW (Somadeva) | 2. Ed. F. Bopp, Berlin, 1832.  PW | 3. In der Sanskrit Chresthomathie von O. Böhtlingk	1694	99	PW
+Na1na1rthak.	NANARTHAK	abbrev	Na1na1rthakos4a	0				
+Na1r.	NAR	xref	Na1ra1yana und Na1rada Dharmas4a1stra	0				
+Na1rada Dharmas4a1stra	NARADADHARMASASTRA	work		1	Ohne weiteres im pw.			pw
+Na1ra1yana	NARAYANA	work		1	Ein Scholiast des Sa1n2kha1yana Gr2hyasu1tra. PW			PW
+Na1ra1yanabhat2t2as Prayogaratna	NARAYANABHATTASPRAYOGARATNA	xref	Prayogaratna	0				
+Na1ra1yanacakravartin	NARAYANACAKRAVARTIN	work		1	Ein Scholiast des Amarakos4a, nach Anführungen im S4KD. PW			PW
+Navarat.	NAVARAT	xref	Navaratna	0				
+Navaratna	NAVARATNA	xref	Ka1vyasam2graha	0				
+Naxatra	NAXATRA	work		1	Die vedischen Nachrichten von den Naxatra. Von A. Weber			
+Berlin, 1860. pw	BERLINPW	work		0				
+Nida1na Su1tra	NIDANASUTRA	work		1	Ohne weiteres im PW und pw.			PW
+Nigh.	NIGH	xref	Nighantu	0				
+Nighan2t2u	NIGHANTU	xref	Nirukta	0				
+Nighan2t2u Praka1s4a	NIGHANTUPRAKASA	work		1	Von Ba1pu Ganga1dhara, Bombay, 1839. PW, pw			PW,pw
+Nigh. Pr.	NIGHPR	xref	Nighantu Praka1s4a	0				
+Ni1l.	NIL	xref	Ni1lakan2t2ha	0				
+Ni1lak.	NILAK	xref	Ni1lakan2t2ha	0				
+Ni1lakan2t2ha	NILAKANTHA	work		2	1. Ein Scholiast des Maha1bha1rata. PW | 2. A Rational Refutation of the Hindu Philosophical Systems by Nehemiah			PW
+Nilarudra Upanis2ad	NILARUDRAUPANISAD	xref	Atharvan2a Upanis2ads	0				
+Ni1lar. Up.	NILARUP	xref	Ni1larudra Upanis2ad	0				
+Nir.	NIR	xref	Nirukta	0				
+Nirn2ajas.	NIRNAJAS	xref	Nirn2ayasindhu	0				
+Nirn2ayasindhu	NIRNAYASINDHU	work		1	Ohne weiteres im pw.			pw
+Nirukta	NIRUKTA	work		1	Von Ya1ska. Ed. R. Roth, Göttingen, 1852.  PW, pw Mit den	1762		PW,pw
+Ni1tipr.	NITIPR	xref	Ni1tipradi1pa	0				
+Ni1tipradi1pa	NITIPRADIPA	xref	Ka1vyasam3graha	0				
+Nja1jam.	NJAJAM	xref	Jaimini1yanya1yama1la1vista1ra	0				
+Nja1jas.	NJAJAS	xref	Nya1yasu1tra	0				
+Nj. K.	NJK	xref	Nya1ya Kos4a	0				
+Notices	NOTICES	work		0				
+Nr2sim3hata1pani1ya Upanis2ad	NRSIMHATAPANIYAUPANISAD	xref	Atharvan2a Upanis2ads	0				
+NR2S. Up.	NRSUP	xref	Nr2sim2hata1pani1ya Upanis2ad	0				
+Nya1ya Kos4a	NYAYAKOSA	work		1	Ed. Bh. Jhalaki1kar, Bombay, 1875.  pw	1806		pw
+Nya1ya Su1tra	NYAYASUTRA	work		1	Von Gotama. || 1. Ed. V. Bhat2t2a1cha1rya, Calcutta, 1828.	1813		
+Old. Buddha	OLDBUDDHA	xref	Oldenberg	0				
+Oldenberg, H.	OLDENBERGH	work		1	Buddha, Berlin, 1881. pw			pw
+Opp. Cat.	OPPCAT	xref	Oppert	0				
+Oppert	OPPERT	work		0				
+Oudh	OUDH	work		0				
+Oxford	OXFORD	work		1	Verzeichnis von Sanskrit Handschriften von Th. Aufrecht. pw			pw
+P.	P	xref	Pa1n2ini1	0				
+Pa1c11akak.	PACAKAK	xref	Pa1s4akakevali1	0				
+Padap.	PADAP	xref	Padapa1tha	0				
+Padapa1tha	PADAPATHA	xref	R2gveda	0				
+Paddhati	PADDHATI	xref	Ma1nava Gr2hyasu1tra	0				
+Padya1vali1	PADYAVALI	work		1	Handschrift. pw			pw
+Pan5cadan2d2acchattraprabandha	PANCADANDACCHATTRAPRABANDHA	work		1	Ed. A. Weber, Berlin, 1877.  pw	1838		pw
+Pan5cara1tra	PANCARATRA	work		1	Von Na1rada. Ed. K. M. Banerjea, Calcutta, 1861-65  pw	1718		pw
+Pan5catantra	PANCATANTRA	work		1	1. Ed. J. G. Kosegarten, Bonn, 1848-59.  PW, pw	1858		PW,pw
+Pan5cavim2s4a Bra1hman2a	PANCAVIMSABRAHMANA	work		1	Ohne weiteres im PW.			PW
+Pa1n2ini	PANINI	work		1	Ed. O. Böhtlingk, Bonn, 1840. PW, pw Mit: Va1rtika1s von Ka1tya1yana			PW,pw
+Pan4k4ad.	PANKAD	xref	Pan5cadan2d2acchattraprabandha	0				
+Pan4k4ar.	PANKAR	xref	Pan5cara1tra	0				
+Pan4k4at.	PANKAT	xref	Pan5catantra	0				
+Pan4k4av. Br.	PANKAVBR	xref	Pan5cavim2s4a Bra1hman2a	0				
+Para1c11.	PARAC	xref	Para1s4ara Dharmas4a1stra	0				
+Para1c11arapaddh.	PARACARAPADDH	xref	Para1s4arapaddhati	0				
+Paramaham2sa Upanis2ad	PARAMAHAMSAUPANISAD	xref	Atharvan2a Upanis2ads	0				
+Parama1rthasa1ra	PARAMARTHASARA	work		1	Ohne weiteres im pw.			pw
+Param. Up.	PARAMUP	xref	Paramaham2sa Upanis2ad	0				
+Para1s4ara Dharmas4a1stra	PARASARADHARMASASTRA	work		1	Nach Anführungen im Mit., Da1j. und S4KD. PW, pw			PW,pw
+Para1s4ara Paddhati	PARASARAPADDHATI	work		1	Ohne weiteres im PW.			PW
+Para1skara Gr2hyasu1tra	PARASKARAGRHYASUTRA	work		1	1. Handschrift. PW. || 2. Ed. A. F. Stenzler, Leipzig, 1876-78. [I.O.			PW
+Pa1r. Gr2hj.	PARGRHJ	xref	Para1skara Gr2hyasu1tra	0				
+Paribh.	PARIBH	xref	Paribha1s2endus4ekhara	0				
+Paribha1s2endus4ekhara	PARIBHASENDUSEKHARA	work		1	Ed. F. Kielhorn, Bombay, 1868-74. pw	1893		pw
+Paris4is2t2aparvan	PARISISTAPARVAN	work		1	Von Hemacandra. Handschrift. pw			pw
+Paris4is2t2a zum Atharvaveda	PARISISTAZUMATHARVAVEDA	work		1	Handschrift. PW, pw			PW,pw
+Pa1rs4vana1thaka1vya	PARSVANATHAKAVYA	work		1	Handschrift. pw			pw
+Pat.	PAT	xref	Patan5jali	0				
+Patan5jali	PATANJALI	work		2	1. Verfasser des Maha1bha1s2ya. In Böhtlingks Pa1n2ini. | 2. s. Yogasu1tra			
+Patja1patjav.	PATJAPATJAV	xref	Patya1patyaviveka	0				
+Pent. (Lassen)	PENTLASSEN	xref	Commentatio	0				
+Phit2su1tra	PHITSUTRA	work		1	Von S4a1ntanava. Ed. F. Kielhorn, Leipzig, 1866.  pw	1915		pw
+Pin2d2apitr2yajn5a	PINDAPITRYAJNA	work		1	Ohne weiteres im pw.			pw
+Pin2d2op.	PINDOP	xref	Pin2d2opanis2ad	0				
+Pin2d2opanis2ad	PINDOPANISAD	xref	Atharvan2a Upanis2ads	0				
+Pischel	PISCHEL	xref	Hemacandras Prakrit Grammatik	0				
+Prabodhacandrodaya	PRABODHACANDRODAYA	work		1	Ed. H. Brockhaus, Leipzig, 1835.  PW, pw	1926		PW,pw
+Pracan2d2apa1n2d2ava	PRACANDAPANDAVA	work		1	Ein Schauspiel. Handschrift. pw			pw
+Prac11nop.	PRACNOP	xref	Pras4na Upanis2ad	0				
+Pra1jac11k4ittav.	PRAJACKITTAV	xref	Pra1yas4cittaviveka	0				
+Praja1pati	PRAJAPATI	work		1	Nach Zitaten in verschiedenen juristischen Werken. pw			pw
+Prajogar.	PRAJOGAR	xref	Pragogaratna	0				
+Prakriya1 Kaumudi1	PRAKRIYAKAUMUDI	work		1	Handschrift. pw			pw
+Prasannar.	PRASANNAR	xref	Prasannara1ghava [pwj46]	0				
+Prasannara1ghava	PRASANNARAGHAVA	work		1	Von Jayadeva. pw			pw
+Pras4na Upanis2ad	PRASNAUPANISAD	xref	Taittiri1ya Upanis2ad	0				
+Prastha1nabheda	PRASTHANABHEDA	xref	Indische Studien	0				
+Pra1t.	PRAT	abbrev	Pra1tis4a1khya	0				
+Prata1par.	PRATAPAR	xref	Prata1parudri1ya	0				
+Prata1parudri1ya	PRATAPARUDRIYA	work		1	Ohne weiteres im pw.			pw
+Pratinj5a1su1tra	PRATINJASUTRA	xref	Indische Studien	0				
+Pra1tis4a1khya zur Taittiri1ya Sam2hita1	PRATISAKHYAZURTAITTIRIYASAMHITA	work		2	1. Ed. W. D. Whitney, New Haven, 1871.  pw | 2. In der einleitung von Roths Nirukta. PW, pw	2691		PW,pw,pw
+Pra1tis4a1khya zur Va1jasaneisam2hita1	PRATISAKHYAZURVAJASANEISAMHITA	work		1	1. Handschrift. PW || 2. s. Indische Studien			PW
+Pratyabdas4uddhi	PRATYABDASUDDHI	work		1	Ohne weiteres im pw.			pw
+Pravar.	PRAVAR	xref	Pravara1dhya1ya	0				
+Pravara1dhya1ya	PRAVARADHYAYA	work		0				
+Pra1s4cittatattva	PRASCITTATATTVA	work		1	Ohne weiteres im pw.			pw
+Pra1yas4cittaviveka	PRAYASCITTAVIVEKA	work		1	Handschrift. pw			pw
+Pra1ys4citta zum Atharvaveda	PRAYSCITTAZUMATHARVAVEDA	work		1	Handschrift. pw			pw
+Prayo1garatna	PRAYOGARATNA	work		1	Ohne weiteres im pw.			pw
+Prij1.	PRIJ	xref	Priyadars4ika1	0				
+Priyadars4ika1	PRIYADARSIKA	work		1	Ed. J. Vidya1sa1gara, Calcutta, 1874.  pw	1988		pw
+Procc. A.S.B.	PROCCASB	abbrev	Proceedings of the Asiatic Society of Bengal.	0				
+Pr. P.	PRP	xref	Pracan2d2apa1n2d2ava	0				
+Pur.	PUR	abbrev	Pura1n2a	0				
+Purush.	PURUSH	xref	Purusottama	0				
+Purus2ottama	PURUSOTTAMA	work		1	Ein Lexikograph. PW			PW
+Pushpas.	PUSHPAS	xref	Pus2pasu1tra	0				
+Pus2pasu1tra	PUSPASUTRA	work		1	Ohne weiteres im PW und pw.			PW
+R.	R	xref	Ra1ma1yana	0				
+Radices	RADICES	work		1	linguage sanscritae. Von W. L. Westergaard, Bonn, 2841. PW, pw			PW,pw
+Ra1g4an.	RAGAN	xref	Ra1janighan2t2u	0				
+Ra1g4at.	RAGAT	xref	Ra1jataran3nini1	0				
+R1g4av.	RGAV	xref	Ra1javallabha	0				
+Ragh.	RAGH	xref	Raghuvam3s4a	0				
+Raghun.	RAGHUN	xref	Raghuna1ndanabhat2t2a1ca1rya	0				
+Raghuna1ndanbhat2t2a1ca1rya	RAGHUNANDANBHATTACARYA	work		1	Ein Scholiast des Tithya1ditattva. PW			PW
+Raghuvam2s4a	RAGHUVAMSA	work		2	1. Ed. Calcutta, 1832.  PW, pw | 2. Ed. A. F. Stenzler, London, 1832.  PW, pw	2034	134	PW,pw
+Ra1jam.	RAJAM	xref	Ra1yamukuta	0				
+Ra1janighan2t2u	RAJANIGHANTU	work		2	1. Ed. R. Garbe, Leipzig, 1882.  pw | 2. Nach Anführungen im S4KD. PW	2055		PW,pw
+Ra1jataran3gini1	RAJATARANGINI	work		3	1. Ed. Calcutta, 1835.  PW | 2. Ed. M. A. Troyer, Paris, 1840-52.  PW, pw | 3. Ed. Kern, pw.	2059	147	PW,PW,pw,pw
+Ra1javallabha	RAJAVALLABHA	work		1	Nach Zitaten im S4KD. PW, pw			PW,pw
+Ra1jendr. Not.	RAJENDRNOT	xref	Notices	0				
+Ra1man.	RAMAN	xref	Ra1mana1tha	0				
+Ra1mana1tha	RAMANATHA	work		1	Ein Kommentator des Amarakos4a. Nach Anfürungen im S4KD. PW			PW
+Ra1mapu1rvat. Up.	RAMAPURVATUP	xref	Ra1mapu1rvata1pani1ya Upanis2ad	0				
+Ra1mapu1rvata1pani1ya Upanis2ad	RAMAPURVATAPANIYAUPANISAD	xref	Atharvan2a Upanis2ads	0				
+Ra1matarkav.	RAMATARKAV	xref	Ra1matarkavagi1s4a	0				
+Ra1matarkavagi1s4a	RAMATARKAVAGISA	work		1	Eine Prakrit Grammtik. pw			pw
+Ra1mata1pani1ya Upanis2ad	RAMATAPANIYAUPANISAD	work		1	Ed. A. Weber, Berlin, 1864. pw			pw
+Ra1ma1yan2a	RAMAYANA	work		2	1. Ed. G. Gorresio, Paris, 1843.  PW, pw | 2. Ed. A. W. Schlegel, Bonn, 1829-33.  PW, pw	2111,2111		PW,pw
+Rasam.	RASAM	xref	Rasaman5jari1 [pwj48]	0				
+Rasaman5jari1	RASAMANJARI	work		1	Nach Anführungen im S4KD. Verz. der Berliner Sanskrit Handschriften Nr.			
+Rasar.	RASAR	xref	Rasaratna1kara	0				
+Rasaratna1kara	RASARATNAKARA	work		1	Ed. R. Gu1ha, Calcutta, 1878.  pw	2148		pw
+Ra1shtrapa1lap.	RASHTRAPALAP	xref	Ra1s2t2rapa1lapariprccha1	0				
+Ra1s2t2rapa1lapariprccha1	RASTRAPALAPARIPRCCHA	work		1	Handschrift in der Pariser Bibliothek. Nach Schiefner. PW			PW
+Ratim.	RATIM	xref	Ratiman5jari1	0				
+Ratiman5jari1	RATIMANJARI	work		1	Ein Werk über Erotik. Nach Anführungen im S4KD. PW			PW
+Ratnak.	RATNAK	xref	Ratnakos4a	0				
+Ratnakos4a	RATNAKOSA	work		1	Ein Wörterbuch, nach Anführungen im S4KD. PW			PW
+Ratnam.	RATNAM	xref	Ratnama1la1	0				
+Ratnama1la1	RATNAMALA	work		1	Ein Wörterbuch, nach Anführungen im S4KD. PW			PW
+Ratna1v.	RATNAV	xref	Ratnama1la1	0				
+Ratna1ali1	RATNAALI	work		1	Ed. Calcutta, 1832.  PW		214	PW
+Ra1yamukuta	RAYAMUKUTA	work		1	Ein Kommentator des Amarakos4a, nach Anführungen im S4KD. PW			PW
+Report	REPORT	xref	Kielhorn	0				
+R2gveda	RGVEDA	work		2	1. Ed. F. Rosen, 1. Buch, London, 1838.  PW | 2. Handschrift. PW, pw Mit Pra1tis4a1khya, Anu3kraman2ika1, Sa1yan2as	2177		PW,PW,pw
+R2ktantra	RKTANTRA	work		1	Ed. A. C. Burnell, Bangalore, 1879.  pw	2194		pw
+Roxb.	ROXB	xref	Roxburg	0				
+Roxburg	ROXBURG	xref	Flora indica	0				
+R2t.	RT	xref	R2tusam2ha1ra	0				
+R2tusam2ha1ra	RTUSAMHARA	work		1	Ed. P. A. Bohlen, Leipzig, 1840.  PW, pw	2201		PW,pw
+Rudrata1lam2ka1rat2ippanaka	RUDRATALAMKARATIPPANAKA	work		1	Ein Werk über Poetik. pw			pw
+R2v.	RV	xref	R2gveda	0				
+S4abdacandrika1	SABDACANDRIKA	work		1	Ein Wörterbuch, nach Anführungen imS4KD. PW, pw			PW,pw
+S4abdakalpadruma	SABDAKALPADRUMA	work		1	Von Ra1dha1ka1ntadeva, 1743-1766. PW, pw			PW,pw
+S4abdama1la1	SABDAMALA	work		1	Ein wörterbuch, nach Anfürungen im S4KD. PW			PW
+S4abdaratna1vali1	SABDARATNAVALI	work		1	Ein Wörterbuch, nach Anführungen im S4KD. PW			PW
+Saddh.	SADDH	xref	Saddharmapun2d2ari1ka	0				
+Sadharmalan3ka1vata1ra	SADHARMALANKAVATARA	work		1	Ohne weiteresim PW.			PW
+Saddharmapun2d2ari1ka	SADDHARMAPUNDARIKA	work		2	1. Hundschrift, nach Schiefner. PW | 2. Im 4. Kapitel von "Le Lotus de la bonne Lois. " Ed. E. Foucaux, Paris			PW
+Saddh. L.	SADDHL	xref	Saddharmalan3ka1vata1ra	0				
+Saduktikarn2a1mr2ta	SADUKTIKARNAMRTA	work		1	Von S4ri1dharada1sa, Handschrift. pw			pw
+S4advim2s4a Bra9hmn2a	SADVIMSABRAHMNA	work		1	Ohne weiteres im PW und pw.			PW
+Sa1h. D.	SAHD	xref	Sa1hitya Darpana	0				
+Sa1hitya Darpana	SAHITYADARPANA	work		2	1. Ed. E. Röer, Calcutta, 1850.  PW, pw | 2. Ed. Calcutta, 1828.  pw	2247	264	PW,pw,pw
+Sahr2daya1loka	SAHRDAYALOKA	work		1	2. Ed. Calcutta, 1828.  pw		264	pw
+Sahr2daya1loka	SAHRDAYALOKA	work		1	Ohne weiteres im pw.			pw
+Sa1j.	SAJ	xref	Sa1yan2a	0				
+S4a1kata1yana	SAKATAYANA	work		1	Ein Scholiast des S4a1kuntala. PW			PW
+Sa1kta1nandataran3gin2i1	SAKTANANDATARANGINI	work		1	Handschrift. pw			pw
+S4a1kuntala	SAKUNTALA	work		5	1. Ed. A. L. Che4zy, Paris, 1830.  PW | 2. Ed. O. Böhtlingk, Bonn, 1842.  PW, pw | 3. Ed. R. Pischel, London, 1877.  pw | 4. Ed. K. Burkhard, Wien, 1884.  pw | 5. Ed. p. Tarkavagi1s4a, Calcutta, 1859-60.  [pw	8,8,9,10,15		PW,PW,pw,pw
+Sa1maveda	SAMAVEDA	work		1	Ed. Th. Benfey, Leipzig, 1848.  PW, pw	2268		PW,pw
+Sa1mav. br.	SAMAVBR	xref	Sa1mavidha1na Bra1hman2a	0				
+Sa1mavidha1na Bra1hman2a	SAMAVIDHANABRAHMANA	work		1	Ed. A. c. Burnell, London, 1873.  pw	2273		pw
+Sam2gi1tada1mod.	SAMGITADAMOD	xref	Sam2gi1tada1modara	0				
+Sam2gi1tada1modara	SAMGITADAMODARA	work		1	Ein Werküber Musik, nach Anführungen im S4KD. PW			PW
+Sam2gi1tasa1rasam2graha	SAMGITASARASAMGRAHA	work		1	Ed. A. C. Thakura, Calcutta, 1832.  pw	2273		pw
+Sam2hita1 Upanis2ad	SAMHITAUPANISAD	work		1	Ed. A. C. Burnell, Mangalore, 1877.  pw	2291		pw
+Sam2hitop.	SAMHITOP	xref	Sam2hita1 Upanis2ad	0				
+S4am2kara	SAMKARA	work		2	1. Ein Scholiast des S4a1kuntala. PW | 2. Ein Kommentator der Brahmasu1tras.			PW
+S4am2karavijaya	SAMKARAVIJAYA	work		1	Ed. J. Pan5ca1nana, Calcutta, 1864-68.  pw	2308		pw
+Sa1m2khjak.	SAMKHJAK	xref	Sa1m2khya Ka1rika1	0				
+Sa1m2khya Ka1rika1	SAMKHYAKARIKA	work		2	1. Ed. Chr. Lassen, Bonn, 1832.  PW | 2. Ed. H. H. Wilson, London, 1837.  PW, pw	2312	270	PW,PW,pw
+Sa1m2khya Philosophie	SAMKHYAPHILOSOPHIE	work		1	The Aphorisms of the Sa1m2khya Philosophy of Kapila. Ed. J. R. Ballantyne			
+Sam2ks2epas4am2karajaya	SAMKSEPASAMKARAJAYA	work		1	Von Ma1dhava. pw			pw
+Sam2n5a1sa Up.	SAMNASAUP	xref	Atharvan2a Upanis2ads	0				
+Sam2n5j. Up.	SAMNJUP	xref	Sam2n5a1sa Up.	0				
+Sam2ska1rakaustubha	SAMSKARAKAUSTUBHA	work		1	Von Anantadeva. pw			pw
+Sam2ska1rat.	SAMSKARAT	xref	Sam2ska1ratattva	0				
+Sam2ska1ratattva	SAMSKARATATTVA	work		1	Nach Anführungen im S4KD. PW			PW
+Sam2skk.	SAMSKK	xref	Sam2ska1rakaustubha	0				
+S4a1ndilya	SANDILYA	work		0				
+S4a1n3kha1yana Bra1hman2a	SANKHAYANABRAHMANA	work		1	Ohne weiteres im PW und pw.			PW
+S4a1n3kha1yana Gr2hyasu1tra	SANKHAYANAGRHYASUTRA	work		2	1. Ed. H. Oldenberg, Oxford, 1886. [I.O 967] pw | 2. Handschrift. PW.			PW,pw
+S4a1n3kha1yana S4rautasu1tra	SANKHAYANASRAUTASUTRA	work		1	Ohne weiteres im PW und pw.			PW
+Sanskrit Chresthomathie	SANSKRITCHRESTHOMATHIE	work		1	Von O. Böhtlingk, St. Petersburg, 1845.  PW, pw Mit:	2356		PW,pw
+Sanscrit Texts	SANSCRITTEXTS	xref	Muir	0				
+S4a1ntana1ca1rya Phit2su1tra	SANTANACARYAPHITSUTRA	work		1	Ed. O. Böhtlingk, St. Petersburg, 1848. pw			pw
+S4a1ntanava	SANTANAVA	xref	Phit2su1tra	0				
+S4a1ntis4ataka	SANTISATAKA	xref	Ka1vyasam2graha	0				
+Saptas4ataka	SAPTASATAKA	work		1	Von Ha1la. Ed. A. Weber, Leipzig, 1870.  pw	2365		pw
+Saptas4ati1	SAPTASATI	work		1	Von Govardhana. pw			pw
+Sa1ras.	SARAS	xref	Sa1rasundari	0				
+Sa1rasundari	SARASUNDARI	work		1	Ein Kommentator des Amarakos4a. PW, pw			PW,pw
+Sarasvati1kan2t2ha1bharan2a	SARASVATIKANTHABHARANA	work		2	1. s. Va1gbhatas Alam2ka1ra | 2. Handschrift. pw			pw
+Sa1ra1v.	SARAV	xref	Sa1ra1vali1	0				
+Sa1ra1vali1	SARAVALI	work		1	Von Utpala. Es wird Vara1hmihiras Br2hatsam2hita1 zitiert. pw			pw
+S4a1rn3gadharapaddhati	SARNGADHARAPADDHATI	work		1	Handschrift im St. Petersburger asiatischen Museum der kaiserlichen			
+S4a1rn3gadhara Sam2hita1	SARNGADHARASAMHITA	work		1	Ohne weiteres im pw.			pw
+Sarvad.	SARVAD	xref	Sarvadars4anasam2graha	0				
+Sarvadars4anasam2graha	SARVADARSANASAMGRAHA	work		1	Ed. J. Vidya1sa1gara, Calcutta, 1853-58.  pw	2391		pw
+Sarvop. S.	SARVOPS	xref	Sarvopanis2atsa1ra	0				
+Sarvopanis2atsa1ra	SARVOPANISATSARA	xref	Atharvan2a Upanis2ads	0				
+S4a1s4vata	SASVATA	xref	Aneka1rthasamuccaya	0				
+S4atapatha Bra1hman2a	SATAPATHABRAHMANA	xref	Yajurveda	0				
+S4atarudri1ya Upanis2ad	SATARUDRIYAUPANISAD	work		1	Ohne weiteres im PW.			PW
+S4atrum2jayamaha1tmya	SATRUMJAYAMAHATMYA	work		1	Ed. A. Weber, Leipzig, 1858.  PW, pw	2421		PW,pw
+S4aun.	SAUN	xref	S4auna1ga	0				
+S4auna1ga	SAUNAGA	work		1	Inder Einleitung zu Böhtlingks Pa1n2ini Ausgabe, S. 66. PW, pw			PW,pw
+Sa1v.	SAV	xref	Sa1vitri1	0				
+Sa1vitri1	SAVITRI	xref	Arjunasama1gama	0				
+Sa1yan2a	SAYANA	work		1	Ein Kommentator zum R2gveda. PW, pw			PW,pw
+Sch. oder Schol.	SCHODERSCHOL	abbrev	Scholiast	0				
+Select Specimens	SELECTSPECIMENS	work		1	of the Theatre of the Hindus. Von H. H. Wilson, London, 1835.	2448		
+Setub.	SETUB	xref	Setubandha	0				
+Setubandha	SETUBANDHA	work		0				
+Siddha1ntam.	SIDDHANTAM	xref	Siddha1ntamukta1vali1	0				
+Siddha1ntamukta1vali1	SIDDHANTAMUKTAVALI	work		1	Nach anführungen im S4KD. PW			PW
+Siddha1ntas4iroman2i	SIDDHANTASIROMANI	work		1	Von BHa1skara. Ed. B. Sa1stri, Benares, 1866.  PW, pw Mit:	2468		PW,pw
+Siddh. C11ir.	SIDDHCIR	xref	Siddha1ntas4iroman2i	0				
+Siddh. K.	SIDDHK	xref	Langhukaumudi1	0				
+S4i1la1n3ka	SILANKA	xref	A1ca1ra1n3gasu1tra	0				
+S4is4upa1lavadha	SISUPALAVADHA	work		1	Von Ma1gha. Ed. V. Mis4ra, S. La1la, Calcutta, 1815.  PW, pw		141	PW,pw
+S4ivana1masahasra	SIVANAMASAHASRA	work		1	Handschrift im asiatischen Museum der kaiserlichen Akadamie der			
+S4iva Pura1n2a	SIVAPURANA	work		1	Handschrift Nr. 126 im Verzeichnis der Oxforder Sansc. hds. pw			pw
+S4iva Upanis2ad	SIVAUPANISAD	xref	Atharvan2a Upanis2ads	0				
+Skanda P.	SKANDAP	xref	Skanda Pura1n2a	0				
+Skanda Pura1n2a	SKANDAPURANA	work		1	Ohne weiteres im PW.			PW
+S4KD	SKD	abbrev	S4abdakalpadruma	0				
+Smaradi1pika1	SMARADIPIKA	work		1	Ein Wörterbuch über Erotik, Nach Anführungen im S4KD. PW			PW
+S4obhanastuti	SOBHANASTUTI	work		1	von s4obhanamuni. In: z. d. d. m. G., 32, 509 ff. pw			pw
+Somadevas Nala	SOMADEVASNALA	xref	Nala	0				
+Somakarmapr.	SOMAKARMAPR	xref	Somakarmapradi1pa	0				
+Somakarmapradi1pa	SOMAKARMAPRADIPA	work		1	Von Ra1ma. Handschrift. pw			pw
+Som. Nal.	SOMNAL	xref	Somadevas Nala	0				
+Spr.	SPR	xref	Indische Sprüche	0				
+S4ra1ddhatattva	SRADDHATATTVA	work		1	Nach Anführungen im S4KD. pw			pw
+S4ri1dharasva1min	SRIDHARASVAMIN	work		1	Nach Anführungen im S4KD. PW			PW
+S4ri1dharasva1min	SRIDHARASVAMIN	work		1	Ein Scholiast der Bhagavadgi1ta1. PW			PW
+S4ri1mi1la1maha1tmya	SRIMILAMAHATMYA	work		1	Handschrift im pw.			pw
+S4r2n3ga1ratilaka	SRNGARATILAKA	xref	Meghadu1ta	0				
+S4rutabodha	SRUTABODHA	work		1	Ed. H. Brockhaus, Leipzig, 1841. PW, pw			PW,pw
+s.s.s.	SSS	xref	Sam2gi1tasa1rasam2graha	0				
+St.	ST	abbrev	Stenzler	0				
+St. Petersburg	STPETERSBURG	work		0				
+Subh.	SUBH	xref	Subhu1ti	0				
+Subha1shitar.	SUBHASHITAR	xref	Subha1s2itaratna1kara	0				
+Subha1s2itaratnabha1n2d2a1yaka	SUBHASITARATNABHANDAYAKA	work		1	Ohne weiteres im pw.			pw
+Subha1s2itaratna1kara	SUBHASITARATNAKARA	work		1	Ed. K. S. Bha1t2avadekar, Bombay, 1871.  pw	2625		pw
+Subha1s2ita1vali1	SUBHASITAVALI	work		1	Von Vallabhadeva. Handschrift. pw			pw
+Subhu1ti	SUBHUTI	work		1	Ein Scholiast des Amarakos4a, Nach Anführungen im S4KD. PW			PW
+Suc11r.	SUCR	xref	Sus4ruta	0				
+S4ukhab.	SUKHAB	xref	S4ukhabodha	0				
+Sukhabodha	SUKHABODHA	work		1	Nach Anführungen im S4KD. PW			PW
+S4ukasam2des4a	SUKASAMDESA	work		1	Ohne weiteres im pw.			pw
+S4ukasaptati	SUKASAPTATI	xref	Anthologia sanscritica [pwj54]	0				
+Sukha1v.	SUKHAV	xref	Sukha1vativyu1ha	0				
+Sukha1vativyu1ha	SUKHAVATIVYUHA	work		1	Ed. M. Müller, Oxford, 1833.  pw	2641		pw
+S4ukrani1ti	SUKRANITI	work		1	E. G. O. Oppert, Madras, 1882.  pw	2644		pw
+S4ulva Su1tra	SULVASUTRA	work		1	Ohne weiteres im pw.			pw
+Sund.	SUND	xref	Sundopasundopa1khya1na	0				
+Sundopasundopa1khya1na	SUNDOPASUNDOPAKHYANA	xref	Indraloka1gamana	0				
+Suparn2.	SUPARN	xref	Suparn2a1dhya1ya	0				
+Suparn2a1dhya1ya	SUPARNADHYAYA	xref	Indische Studien	0				
+Su1rjad.	SURJAD	xref	Su1ryadevayajvan	0				
+Su1rjas.	SURJAS	xref	Su1ryasiddha1nta	0				
+Su1ryadevayajvan	SURYADEVAYAJVAN	work		1	Ohne weiteres im pw.			pw
+Su1ryasiddha1nta	SURYASIDDHANTA	work		2	1. Nach Anführungen in Haughtons Wörterbuch. PW | 2. Ed. B. D. S4a1stri1, Calcutta, 1861.  pw	2661		PW,pw
+Sus4ruta	SUSRUTA	work		2	1. Ed. F. Hessler, Erlangen, 1844.  PW, pw | 2. Ed. M. Gupta, Calcutta, 1835.  PW, pw		368,367	PW,pw
+Suvarn2apr.	SUVARNAPR	xref	Suvarn2aprabha1s2a	0				
+Suvarn2aprabha1s2a	SUVARNAPRABHASA	work		1	Ein Buddhistisches Werk. PW			PW
+SV.	SV	xref	Sa1maveda	0				
+Svapnacinta1man2i1	SVAPNACINTAMANI	work		1	Von Jagaddeva. pw			pw
+Svapnak4.	SVAPNAK	xref	Svapnacinta1man2i1	0				
+SV. A1r.	SVAR	xref	A1ran2yaka zum Sa1maveda	0				
+S4veta1s4vatara Upanis2ad	SVETASVATARAUPANISAD	xref	Taittiri1ya Upanis2ad	0				
+Taitt. A1r.	TAITTAR	xref	Taittiri1ya A1ran2yaka	0				
+Taitt. Br.	TAITTBR	xref	Taittiri1ya Bra1hman2a	0				
+Taittiri1ya A1ran2yaka	TAITTIRIYAARANYAKA	work		1	Ed. R. Mitra, Calcutta, 1864. 1872.  PW, pw	2689		PW,pw
+Taittiri1ya Bra1hman2a	TAITTIRIYABRAHMANA	work		1	Ohne weiteres im PW und pw.			PW
+Taittiri1ya Sam2hita1	TAITTIRIYASAMHITA	work		1	Handschrift. PW, pw Mit: Pra1tis4a1khya und Anukraman2ika1			PW,pw
+Taittiri1ya Upanis2ad	TAITTIRIYAUPANISAD	work		1	Ed. E. Röer. Calcutta, 1853.  PW, pw Mit: Taittiri1ya Up.	2802		PW,pw
+Taitt. Pra1t.	TAITTPRAT	xref	Taittiri1ya Sam3hita1 und Pra1tis4a1khya zur Taitt.	0				
+Taitt. Up.	TAITTUP	xref	Taittiri1ya Upanis2ad	0				
+Talavaka1ra Bra1hman2a	TALAVAKARABRAHMANA	work		1	Ed. A. C. Burnell, Mangalore, 1878.  pw	162		pw
+Tal. Br.	TALBR	xref	Talavaka1ra Bra1hman2a	0				
+Ta1n2d2j. Br.	TANDJBR	xref	Ta1n2d2ya Bra1hman2a	0				
+Ta1n2d2ya Bra1hman2a	TANDYABRAHMANA	work		1	Ed. A. Veda1ntava1gi1s4a, Calcutta, 1869-74.  pw	1864		pw
+Tantras.	TANTRAS	xref	Tantrasa1ra	0				
+Tantrasa1ra	TANTRASARA	work		1	Nach Anführungen im S4KD. PW			PW
+Tattvakaumudi1	TATTVAKAUMUDI	work		1	Ohne weiteres im pw.			pw
+Tattvas.	TATTVAS	xref	Tattvasama1sa	0				
+Tattvasama1sa	TATTVASAMASA	work		1	A Lecture on the Sa1m2khya Philosophy. Ed. J. R. Ballantyne, Mirzapore			
+T.Br.	TBR	xref	Taittiri1ya Bra1hman2a	0				
+Teg4ob.	TEGOB	xref	Tejobindu1panis2ad	0				
+Tejobindu1panis2ad	TEJOBINDUPANISAD	xref	Atharvan2a Upanis2ads	0				
+Tibetische Lebensbeschreibung	TIBETISCHELEBENSBESCHREIBUNG	xref	Lebensbeschreibung	0				
+Tib. Lebensb. C11a1kj.	TIBLEBENSBCAKJ	xref	Tibetische lebensbeschreibung	0				
+Tithja1dit.	TITHJADIT	xref	Tithya1ditattva	0				
+Tithya1ditattva	TITHYADITATTVA	work		1	Nach Anführungen im S4KD. PW			PW
+Trans. R.A.S.	TRANSRAS	abbrev	The Transactions of the Royal Asiatic Society of Great	0				
+Trik.	TRIK	xref	Trika1n2d2as4es4a	0				
+Trika1n2d2as4es4a	TRIKANDASESA	work		1	Ed. H. T. Colebrooke, Calcutta, 1807.  PW, pw		258	PW,pw
+Tripras4na1dhika1ra	TRIPRASNADHIKARA	work		1	Ohne weiteres im pw.			pw
+TS.	TS	xref	Taittiri1ya Sam2hita1	0				
+TS. Anukr.	TSANUKR	xref	Taittiri1ya Sam2hita1	0				
+TS. Pra1t.	TSPRAT	xref	Pra1tis4a1khya zur Taittiri1ya Sam2hita1 [pwj56]	0				
+Udva1hat.	UDVAHAT	xref	Udva1hatttva	0				
+Udva1hatattva	UDVAHATATTVA	work		1	nach Anführungen im S4KD. pw			pw
+Ug4g4val.	UGGVAL	xref	Ujjvaladatta	0				
+Ujjvaladatta	UJJVALADATTA	xref	Un2a1disu1tras	0				
+Un2.	UN	xref	Un2a1di Affixe	0				
+Un2a1di Affixe	UNADIAFFIXE	work		1	Ed. O. Böhtlingk, St. Petersburg, 1844.  PW	2788		PW
+Un2a1dik.	UNADIK	xref	Un2a1dikos4a	0				
+Un2a1dikos4a	UNADIKOSA	work		1	Nach Anführungen im S4KD. PW			PW
+Un2a1dis.	UNADIS	xref	Un2a1disu1tra	0				
+Un2a1disu1tra	UNADISUTRA	work		0				
+Up. und Upak.	UPUNDUPAK	xref	Upakos4a	0				
+Upag. Av.	UPAGAV	xref	Upagupta1vada1na	0				
+Upagupta1vada1na	UPAGUPTAVADANA	work		1	Handschrift in der Pariser Bibliothek. PW Nach Schiefner.			PW
+Upakos4a	UPAKOSA	work		0				
+Upal.	UPAL	xref	Upalekha	0				
+Upalekha	UPALEKHA	work		1	Ed. W. Pertsch, Berlin, 1854.  PW	2796		PW
+Uttaracaritrakatha1nakam	UTTARACARITRAKATHANAKAM	work		1	In: Sitzungsberichte der königlich oreuss. Ak. der Ww. zu berlin, 1884			
+Uttarar.	UTTARAR	xref	uttarara1macarita	0				
+Uttarara1macarita	UTTARARAMACARITA	work		2	1. Ed. Calcutta, 1831.  PW, pw | 2. Ed. P. tarkavagi1s4a, Calcutta, 1862.  pw	2830,2832		PW,pw,pw
+Utt. Ra1ma K.	UTTRAMAK	xref	Uttarara1macarita	0				
+Va1ghbhat2t2as Alam2ka1ra	VAGHBHATTASALAMKARA	work		1	Ed. A. Boroah, London, Calcutta, 1883.  pw Mit:	1316		pw
+Vag4rak4k4h.	VAGRAKKH	xref	Vajracchedika	0				
+Vag4ras.	VAGRAS	xref	Vajrasu1ci1 [pwj57]	0				
+Vag4ra1sanasa1dhanam.	VAGRASANASADHANAM	xref	Vajra1sanasa1dhanama1la1	0				
+Vaidjabh.	VAIDJABH	xref	Vaidhyabha1s2ya	0				
+Vaidyabha1s2ya	VAIDYABHASYA	work		1	Ohne weiteres im pw.			pw
+Vaij.	VAIJ	xref	Vaijayanti	0				
+Vaijayanti	VAIJAYANTI	work		1	Ein Wörterbuch, Excerpte daraus von A. F. Stenzler. PW			PW
+Vais4es2ikha	VAISESIKHA	work		0				
+Vaita1n.	VAITAN	xref	Vaita1nasu1tra	0				
+Vaita1nasu1tra	VAITANASUTRA	work		1	Ed. R. Garbe, Strassburg, 1878.  pw	2867		pw
+Va1jasaneyisam2hita1	VAJASANEYISAMHITA	xref	Yajurveda	0				
+Vajracchedika	VAJRACCHEDIKA	work		1	Ed. F. M. Müller, Oxford, 1881.  pw	2874		pw
+Vajra1sanasa1dhanama1la1	VAJRASANASADHANAMALA	work		1	Handchrift in der Pariser Bibliothek. Nach Schiefer. PW			PW
+Vajrasu1ci1	VAJRASUCI	work		1	Ed. A. Weber, Berlin, 1860.  pw	2875		pw
+Va1ju P.	VAJUP	xref	Va1yu Pura1n2a	0				
+Va1lakh.	VALAKH	xref	Va1lakhilya	0				
+Va1lakhilya	VALAKHILYA	work		1	Die zwischen R2gveda 8, 48, 49 eingeschobenen Lieder. PW, pw			PW,pw
+Va1mana	VAMANA	xref	Ka1ya1lam2ka1ra	0				
+Va1mana Pura1n2a	VAMANAPURANA	work		1	Handschrift. pw			pw
+Vam2c11a Br.	VAMCABR	xref	Vam2s4a Bra1hman2a	0				
+Vam2s4a Bra1hman2a	VAMSABRAHMANA	work		1	Ed. A. C. Burnell, Mangalore, 1873.  pw	2887		pw
+Var.	VAR	abbrev	Variante	0				
+Vara1hamihira	VARAHAMIHIRA	xref	Br2hajja1taka, Br2hatsam2hita1, Laghuja1taka,	0				
+Vara1ha Pura1n2a	VARAHAPURANA	work		1	Handschrift. PW, pw			PW,pw
+Vara1h. Br2h.	VARAHBRH	xref	Br2hajja1taka	0				
+Vara1h. Br2hs.	VARAHBRHS	xref	Br2hatsam2hita1	0				
+Vara1h. Lagh.	VARAHLAGH	xref	Laghuja1taka	0				
+Vardhama1na Caritra	VARDHAMANACARITRA	work		1	Handschrift. pw			pw
+Va1r. P.	VARP	xref	Va1ra1ha Pura1n2a	0				
+Va1rt.	VART	xref	Va1rtika1	0				
+Va1rtika1	VARTIKA	work		1	Von Ka1tya1yana zu Pa1n2ini. In Böhtlingks Ausgabe des Pa1n2ini. PW, pw			PW,pw
+Va1s.	VAS	xref	Va1santika1	0				
+Va1santika1	VASANTIKA	work		1	Handschrift. pw			pw
+Va1sav.	VASAV	xref	Va1savadatta1	0				
+Vasis2t2ha Dharmas4a1stra	VASISTHADHARMASASTRA	work		1	Ed. A. A. Führer, Poona, 1830.  pw	2910		pw
+Va1stuv.	VASTUV	xref	Va1stuvidya1	0				
+Va1stuvidya1	VASTUVIDYA	work		1	Von Vis4vakarman. Handschrift. pw			pw
+Va1yu Pura1n2a	VAYUPURANA	work		0				
+ved.	VED	abbrev	vedisch	0				
+Veda1ntas.	VEDANTAS	xref	Veda1ntasa1ra	0				
+Veda1ntasa1ra	VEDANTASARA	work		2	1. Ed. Calcutta, 1829.  PW | 2. Ed. J. R. Ballantyne, Allahabad, 1850.  PW	2937	279	PW
+Veda P.	VEDAP	xref	Veda Pura1n2a	0				
+Veda Pura1n2a	VEDAPURANA	work		1	Ohne weiteres im PW.			PW
+Ven2is.	VENIS	xref	Ven2isam2ha1ra	0				
+Ven2isam2ha1ra	VENISAMHARA	work		2	1. Nach Anführungen im S4KD. PW | 2. Ed. J. Grill, Leipzig, 1871.  pw	2951		PW,pw
+Verh. d.k.s.G.d.Ww.	VERHDKSGDWW	abbrev	Verhandlungen der königlich sächsischen	0				
+Verz. d.B.H.	VERZDBH	xref	Berlin	0				
+Verz. d. Pet. H.	VERZDPETH	xref	St. Petersburg	0				
+Vet.	VET	xref	Veta1lapan5cavim2s4atika	0				
+vata1lapan5cavim2s4atika	VATALAPANCAVIMSATIKA	work		2	1. In: Anthologia sanscritica. PW, pw | 2. Ed. H. Uhle, Leipzig, 1881.  pw	2969		PW,pw,pw
+Vic11v.	VICV	xref	Vis4vamitras Kampf	0				
+Vic11vak.	VICVAK	xref	Vic11vakos4a [pwj59]	0				
+Vid.	VID	xref	Geschichte des Vidu1s4aka	0				
+Vidagdhamukham.	VIDAGDHAMUKHAM	xref	Vidagdhamukhaman2d2ana	0				
+Vidagdhamukhaman2d2ana	VIDAGDHAMUKHAMANDANA	work		1	Nach Anführungen im S4KD. PW			PW
+Viddh.	VIDDH	xref	Viddhas4alabhan5jikha1khya1na1nat2ika1	0				
+Viddhas4a1labhan5jikha1khya1na1nat2ika1	VIDDHASALABHANJIKHAKHYANANATIKA	work		1	In der Zeitschrift Pratnakmranan2d2ini1. pw			pw
+Vikr.	VIKR	xref	Vikramorvas4i1	0				
+Vikraman3kak4.	VIKRAMANKAK	xref	Vikraman3kacarita	0				
+Vikraman3kacarita	VIKRAMANKACARITA	work		1	Ed. G. Bühler, Bombay, 1875.  pw	1875		pw
+Vikramorvas4i1	VIKRAMORVASI	work		2	Ed. F. Bollensen, Leipzig, St. Petersburg, 1846.  PW, pw | 2. Nach dravidischen Handschriften, herausgegeben von R. Pischel in:	2991		PW,pw
+Vikr. drav.	VIKRDRAV	xref	Vikramorvas4i1	0				
+Vi1ram.	VIRAM	xref	Vi1ramitrodaya	0				
+Vi1ramitrodaya	VIRAMITRODAYA	work		1	Ed. Calcutta, 1815.  PW, pw	3005		PW,pw
+Vis2n2u Su1tra	VISNUSUTRA	work		2	Ed. H. H. Wilson, London, 1840.  PW, pw | Unbekannte Bombayer Ausgabe. pw	3021		PW,pw,pw
+Vis2n2u Su1tra	VISNUSUTRA	work		1	Ed. J. Jolly, Oxford, 1880.  pw	3033		pw
+Viva1dacinta1man2i1	VIVADACINTAMANI	work		2	1. Ed. R. Vidya1va1gi1s4a, Calcutta, 1837.  PW | 2. Ed. R. Vidya1va1gi1s4a, Calcutta, 1894. PW		351	PW
+Viva1dak4.	VIVADAK	xref	Viva1dacinta1man2i1	0				
+Viva1da1rn2.	VIVADARN	xref	Viva1da1rn2avasetu	0				
+Vivada1rn2avasetu	VIVADARNAVASETU	work		1	Nach Anführungen im S4KD. PW			PW
+Vivekav.	VIVEKAV	xref	Vivekavila1sa	0				
+Vivekavila1sa	VIVEKAVILASA	work		1	In der Zeitschrift Pratnakamranandini1. pw			pw
+Vis4vakos4a	VISVAKOSA	work		1	Ohne weiteres im pw.			pw
+Vjut.	VJUT	xref	Vyutpatti [pwj60]	0				
+V.L.	VL	abbrev	Varia Lectio	0				
+Vop.	VOP	xref	Vopadeva	0				
+Vopadeva	VOPADEVA	xref	Mugdhabodha	0				
+VP.	VP	xref	Vis2n2u Pura1n2a	0				
+Vr2s2abha1nuja	VRSABHANUJA	work		1	Im 3. und 4. Buch des Pandit. pw			pw
+Vr2shabh.	VRSHABH	xref	Vr2s2abha1nuja	0				
+VS.	VS	work		0				
+Vyutpatti	VYUTPATTI	work		1	Ein Sanskrit-tibetisch-mongolisches Wörterbuch. Nach Schiefner. PW St.			PW
+West.	WEST	xref	Westergaard	0				
+Westergaard	WESTERGAARD	xref	Radices	0				
+Willmot, E.	WILLMOTE	work		0				
+Wils.	WILS	xref	Wilson	0				
+Wilson, H.H.	WILSONHH	work		0				
+Windischmann, F.H.H.	WINDISCHMANNFHH	work		0				
+Wind. Sanc.	WINDSANC	xref	Windischmann	0				
+Wise	WISE	xref	Commentary	0				
+Yajn5adattavadha	YAJNADATTAVADHA	work		1	Ed. A. L. Deslongchamps, Paris, 1829. PW			PW
+Ya1jn5yavalkyas Gesetzbuch	YAJNYAVALKYASGESETZBUCH	work		1	Ed. A. F. Stenzler, Berlin, 1849.  PW, pw	3094		PW,pw
+Yajurveda	YAJURVEDA	work		1	Ed. A. Weber, london, Berlin, 1852-59.  PW, pw Mit: S4atapatha	3085		PW,pw
+Yogara1tra	YOGARATRA	xref	Indische Studien	0				
+Yogas4a1stra	YOGASASTRA	work		1	Von Hemacandra. In: Z. d. d. m. G. 28. pw			pw
+Yogas4ikha Upanis2ad	YOGASIKHAUPANISAD	xref	Atharvan2a Upanis2ads	0				
+Yogasu1tra	YOGASUTRA	work		1	Von Patan5jali. Ed. J. R. Ballantyne, Allahabad, 1852. I.O. 3137] PW, pw			PW,pw
+Yogatattva	YOGATATTVA	xref	Indisch Studien	0				
+Yogatattva Upanis2ad	YOGATATTVAUPANISAD	xref	Atharvan2a Upanis2ads	0				
+Yuktikalpataru	YUKTIKALPATARU	work		1	Ohne weiteres im PW.			PW
+Zach. Beitr.	ZACHBEITR	xref	Beiträge <i>Z.d.d.m.G.</i> = Zeitschrift der	0				
+Z.f.d.K.d.M.	ZFDKDM	abbrev	Zeitschrift für die Kunde des Morgenlandes	0				
+Z.f.d.W.d.Spr.	ZFDWDSPR	abbrev	Zeitschrift für die Wissenschaft der Sprache.	0				
+Z. f. vgl. Spr.	ZFVGLSPR	abbrev	Zeitschrift für vergleichende Sprachforschung auf	0				
+Zur Geschichte	ZURGESCHICHTE	work		1	der griechichen und indoskythischen Könige in Baktrien, Kabul, und Indien			
+Zur Literatur und Geschichte des Veda (Z. L. u. G. d. W. )	ZURLITERATURUNDGESCHICHTEDESVEDAZLUGDW	work		0				
+Zwölf Hymnen	ZWLFHYMNEN	work		1	des R2gveda. Ed. E. Windisch. Seite 169 ff.			

--- a/pw_ls/pwbib/jachertz/jachertz_parse.py
+++ b/pw_ls/pwbib/jachertz/jachertz_parse.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+"""
+jachertz_parse.py  (Opus 4.8, 2026-07-02)
+
+Parse the digitized Jachertz 1983 bibliography (pw-jachertz-utf8.txt) into a
+structured, queryable table, and attempt a conservative backfill of the
+UNRESOLVED entries in the pwbib "list of works" (mergebibnew.txt, flag=0 / '?').
+
+Outputs (all in this folder; none overwrite canonical pwbib data):
+  jachertz_bib.tsv                 - one row per Jachertz entry
+  jachertz_backfill_candidates.tsv - pwbib stub -> Jachertz match candidates (REVIEW)
+  jachertz_parse_log.txt           - counts + how to read the outputs
+
+Run:  python jachertz_parse.py
+"""
+import re, sys, os
+sys.stdout.reconfigure(encoding='utf-8'); sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PWBIB = os.path.normpath(os.path.join(HERE, '..'))
+JTXT = os.path.join(HERE, 'orig', 'pw-jachertz-utf8.txt')
+MERGE = os.path.join(PWBIB, 'pwbib_new_work', 'mergebibnew.txt')
+
+def norm_key(s):
+    """Match key across differing AS digit schemes: drop digits/punct, uppercase.
+    Jachertz a1=a-macron and pwbib A7=A-macron both collapse to the base letter."""
+    return re.sub(r'[^A-Za-z]', '', s).upper()
+
+YEAR = re.compile(r'\b(1[5-9]\d\d)\b')
+IO   = re.compile(r'\[I\.O\.\s*(\d+)\]')
+GILD = re.compile(r'\[Gild\.\s*(\d+)\]')
+PWJ  = re.compile(r'\[pwj\d+\]')
+DICTS= re.compile(r'\b(PW,\s*pw|PW|pw)\b')
+
+def parse_editions(edlines):
+    eds = []
+    for raw in edlines:
+        t = raw.strip()
+        t = re.sub(r'^<p>--\.*\s*', '', t)          # strip the "--..." lead
+        io = IO.search(t)
+        gild = GILD.search(t)
+        yr = YEAR.findall(t)
+        di = DICTS.findall(t)
+        clean = PWJ.sub('', GILD.sub('', IO.sub('', t))).strip().rstrip(';,')
+        eds.append({
+            'text': clean,
+            'year': yr[-1] if yr else '',
+            'io': io.group(1) if io else '',
+            'gild': gild.group(1) if gild else '',
+            'dicts': ('PW,pw' if any(',' in d for d in di) else
+                      'PW' if 'PW' in di else 'pw' if 'pw' in di else ''),
+        })
+    return eds
+
+def parse():
+    lines = open(JTXT, encoding='utf-8').read().splitlines()
+    entries = []
+    i = 0
+    hb = re.compile(r'^\s*<p><b>(.+?)</b>(.*)$')
+    while i < len(lines):
+        m = hb.match(lines[i])
+        if not m:
+            i += 1; continue
+        head, rest = m.group(1).strip(), m.group(2).strip()
+        if rest.startswith('='):
+            entries.append({'head': head, 'type': 'abbrev', 'target': rest[1:].strip(),
+                            'editions': []})
+            i += 1
+        elif rest.startswith('s.') or rest.startswith('s '):
+            entries.append({'head': head, 'type': 'xref',
+                            'target': rest[2:].strip().lstrip('.').strip(), 'editions': []})
+            i += 1
+        else:
+            # a work: gather following '--' edition lines
+            eds = []
+            j = i + 1
+            while j < len(lines):
+                s = lines[j].strip()
+                if s.startswith('<p>--'):
+                    eds.append(lines[j]); j += 1
+                elif s == '':
+                    j += 1
+                    # allow a blank between head and first edition, but stop at next <b>
+                    if j < len(lines) and hb.match(lines[j]):
+                        break
+                    if eds:  # blank after editions ends the block
+                        break
+                else:
+                    break
+            entries.append({'head': head, 'type': 'work',
+                            'target': '', 'editions': parse_editions(eds)})
+            i = j
+    return entries
+
+def write_bib(entries):
+    out = os.path.join(HERE, 'jachertz_bib.tsv')
+    with open(out, 'w', encoding='utf-8', newline='\n') as f:
+        f.write('head_as\tkey\ttype\ttarget\tn_ed\teditions\tio_shelfmarks\tgild_shelfmarks\tdicts\n')
+        for e in entries:
+            eds = e['editions']
+            edtext = ' | '.join(x['text'] for x in eds)
+            ios = ','.join(x['io'] for x in eds if x['io'])
+            gilds = ','.join(x['gild'] for x in eds if x['gild'])
+            dic = ','.join(sorted({x['dicts'] for x in eds if x['dicts']}))
+            f.write(f"{e['head']}\t{norm_key(e['head'])}\t{e['type']}\t{e['target']}\t"
+                    f"{len(eds)}\t{edtext}\t{ios}\t{gilds}\t{dic}\n")
+    return out
+
+def load_stubs():
+    stubs = []
+    for ln in open(MERGE, encoding='utf-8'):
+        p = ln.rstrip('\n').split(':')
+        if len(p) >= 5 and p[3] == '0' and p[4].strip() in ('?', ''):
+            stubs.append({'abbrvsort': p[0], 'abbrv': p[1], 'id': p[2]})
+    return stubs
+
+def backfill(entries, stubs):
+    # index works + resolve xrefs to their work
+    works = {e['head']: e for e in entries if e['type'] == 'work'}
+    xref  = {norm_key(e['head']): e['target'] for e in entries if e['type'] == 'xref'}
+    work_by_key = {}
+    for e in entries:
+        if e['type'] == 'work':
+            work_by_key.setdefault(norm_key(e['head']), e)
+    cands = []
+    for st in stubs:
+        k = norm_key(st['abbrvsort'])
+        match, how = None, ''
+        # 1) exact key hit on a work
+        if k in work_by_key:
+            match, how = work_by_key[k], 'exact'
+        else:
+            # 2) via xref abbreviation -> work
+            if k in xref:
+                tk = norm_key(xref[k])
+                if tk in work_by_key:
+                    match, how = work_by_key[tk], 'xref'
+            # 3) prefix: stub key is a prefix of a work key (>=5 chars, unique)
+            if match is None and len(k) >= 5:
+                pref = [w for wk, w in work_by_key.items() if wk.startswith(k)]
+                if len(pref) == 1:
+                    match, how = pref[0], 'prefix'
+        if match:
+            eds = match['editions']
+            cands.append((st['abbrvsort'], st['id'], how, match['head'],
+                          ' | '.join(x['text'] for x in eds),
+                          ','.join(x['io'] for x in eds if x['io']),
+                          ','.join(x['gild'] for x in eds if x['gild'])))
+    out = os.path.join(HERE, 'jachertz_backfill_candidates.tsv')
+    with open(out, 'w', encoding='utf-8', newline='\n') as f:
+        f.write('pwbib_abbrv\tpwbib_id\tmatch_how\tjachertz_head\teditions\tio_shelfmarks\tgild_shelfmarks\n')
+        for c in cands:
+            f.write('\t'.join(c) + '\n')
+    return out, cands
+
+if __name__ == '__main__':
+    entries = parse()
+    nb = write_bib(entries)
+    stubs = load_stubs()
+    bf, cands = backfill(entries, stubs)
+    byhow = {}
+    for c in cands: byhow[c[2]] = byhow.get(c[2], 0) + 1
+    ntyp = {}
+    for e in entries: ntyp[e['type']] = ntyp.get(e['type'], 0) + 1
+    ned = sum(len(e['editions']) for e in entries)
+    nio = sum(1 for e in entries for x in e['editions'] if x['io'])
+    ngild = sum(1 for e in entries for x in e['editions'] if x['gild'])
+    log = os.path.join(HERE, 'jachertz_parse_log.txt')
+    with open(log, 'w', encoding='utf-8', newline='\n') as f:
+        f.write("jachertz_parse.py run summary\n")
+        f.write(f"entries parsed: {len(entries)}  by type: {ntyp}\n")
+        f.write(f"total editions: {ned}   with I.O. shelfmark: {nio}   with Gild. shelfmark: {ngild}\n")
+        f.write(f"pwbib unresolved stubs (flag=0/'?'): {len(stubs)}\n")
+        f.write(f"backfill candidates: {len(cands)}  by method: {byhow}\n")
+        f.write("\nNOTE: candidates are for HUMAN REVIEW; nothing is written back to\n")
+        f.write("mergebibnew.txt or any canonical pwbib file. 'prefix' matches are the\n")
+        f.write("least certain (stub abbreviation is a prefix of exactly one work key).\n")
+    print(open(log, encoding='utf-8').read())
+    print('wrote:', os.path.basename(nb), os.path.basename(bf), os.path.basename(log))

--- a/pw_ls/pwbib/jachertz/jachertz_parse_log.txt
+++ b/pw_ls/pwbib/jachertz/jachertz_parse_log.txt
@@ -1,0 +1,9 @@
+jachertz_parse.py run summary
+entries parsed: 1169  by type: {'work': 503, 'xref': 626, 'abbrev': 40}
+total editions: 522   with I.O. shelfmark: 155   with Gild. shelfmark: 32
+pwbib unresolved stubs (flag=0/'?'): 287
+backfill candidates: 37  by method: {'exact': 12, 'prefix': 8, 'xref': 17}
+
+NOTE: candidates are for HUMAN REVIEW; nothing is written back to
+mergebibnew.txt or any canonical pwbib file. 'prefix' matches are the
+least certain (stub abbreviation is a prefix of exactly one work key).

--- a/pw_ls/pwbib/jachertz/orig/pw-jachertz-utf8.txt
+++ b/pw_ls/pwbib/jachertz/orig/pw-jachertz-utf8.txt
@@ -1,0 +1,3411 @@
+%***This_File_is_C:\USERS\ACER_LLC\DROPBOX\AAA_CURRENT_TEMP\PW-JACHERTZ.TXT,_Last_update_11/16/15
+thomas.jachertz@klinik-lueneburg.de
+
+
+<title>
+<p>Jachertz, Thomas : Beiträge zu einer bibliographischen Übersicht über die
+textliche Basis unserer europäischen Sanskritwörterbücher, vorzüglich des
+grossen Petersburger Wörterbuches (PW) und des kleinen Petersburger Wörterbuches
+(pw)
+
+<p>Magisterarbeit
+
+<p>Vorgelegt im Sommersemester 1983 [pwj1]
+</title>
+
+<h1>Vorwort
+
+<p>Vor der bibliographischen Übersicht über die textliche Grundlage zum grossen
+Petersburger Wörterbuch (PW) und zum kleinen Petersburger Wörterbuch (pw) seien
+einige Bemerkungen vorangestellt, die allgemein für das Verständnis der heutigen
+Lage auf dem Gebiet der Sanskritlexikographie von Interesse sein könnten.
+
+<h1>I.
+
+<p>Bis heute ist das grosse Petersburger Wörterbuch von Rudolph Roth (1821-1894)
+und O. Böhtlingk (1815-1904) die Grundlage der Sanskritlexikologie im
+deutschsprachigen Raum und darüber hinaus geblieben.
+
+<p>Es erschien als Ausgabe der kaiserlichen Akademie der Wissenschaften zu St.
+Petersburg ebenda in 7 Teilen zwischen den Jahren 1852 bis 1875.
+
+<p>Der erste Teil wurde zu einer Zeit veröffentlicht, als die Sanskritphilologie in
+Deutschland bereits seit 34 Jahren bestand, wenn man etwas willkürlich die
+Gründung des Bonner Lehrstuhls für Indologie im Jahre 1818 als den Anfang
+derselben ansehen will. Bisher existierte lediglich ein wichtiges Lexikon
+<i>"Sanskrit-Englisch,"</i> welches H.H. Wilson 1819 mit Hilfe einheimischer Pandits
+in Calcutta herausbrachte und von dem 1832 eine verbesserte Auflage erschien.
+Wie jedoch R. Roth und O. Böhtlingk im Vorwort des 1. Bandes zum PW bemerkten,
+handelte es sich hierbei nur um eine Sammlung von Worten und Wortbedeutungen,
+nicht aber um eine echte Bearbeitung des Sprachwortschatzes. Zudem war die Zahl
+der Sanskritisten in Deutschland erheblich angewachsen, so dass daher schon ein
+grosses Bedürfnis nach einem den neuen Ansprüchen genügenden Wörterbuch bestand,
+bei dem Sanskritwörter durch andere Wörter erklärt werden.
+
+<p>Ein Wörterbuch kann in verschiedener Form und Absicht gestaltet werden, z.B.: a)
+als Belegwörterbuch mit Belegstellen aus der Literatur, b) als ein reines
+Sprachwörterverzeichnis, c) als Wortindex zu einem bestimmten werk, d) als
+Kryptowörterbuch etwa in Form eines beigefügten Spezialglossars zu einer
+Chresthomathie, e) als synonymisches Wörterbuch, f) als etymologisches
+Wörterbuch, [pwj2] g) als Spezialwörterbuch zu einem bestimmten Thema order zu
+einer bestimmten Zeitperiode. Aus dieser Fülle theoretischer Möglichkeiten, ein
+Wörterbuch zu gestalten, hatten R. Roth und O. Böhtlingk die Auswahl zu treffen.
+Da fürs Indische ausser Wilsons Wörterbuch im wesentlichen nur Übersetzungen
+vorlagen, fiel die Wahl auf die Herstellung eines enzyklopädischen Werkes, in
+dem der gesamte Literaturzeitraum der Sanskritsprache aufgearbeitet werden
+sollte mit Einbeziehung sämtlicher Spezialliteraturen wie z.B. die der Medizin
+oder die der Grammatik. Es wurde somit eine lexikologische Basis für die
+Sanskritphilologie geschaffen, auf der dann später weitere Wörterbucharbeiten
+aufbauen könnten, die vor allem für den praktischen Gebrauch günstig sein
+würden, etwa Spezialwörterbücher für eine bestimmte Zeitperiode.
+
+<p>Aus zwei Quellen wurde nun wohl das Material für die Herstellung des PW
+genommen: einmal aus den Wortsammlungen indischer Gelehrter, die, wenn sie noch
+nicht hier waren, dem Sabdakalpadruma von Ra1ja1 Ra1dha1ka1nta entnommen wurden.
+Dies trifft auch für Wörterbücher aus der Botanik und aus anderen s4a1stras zu.
+Das s4abdakalpadruma, gedruckt in Calcutta 1821-1857, war noch nicht im
+Buchhandel erhältlich, aber als Exemplar der Kaiserlichen Akademie der
+Wissenschaften zu St. Petersburg verfügbar.
+
+<p>Die andere Quelle war die Sanskritliteratur selber, die von R. Roth und O.
+Böhtlingk selbständig erarbeitet werden musste, weil ihnen die Kommentare
+indischer Tradition für die Ansprüche moderner Philologie als nicht ausreichend
+und zu ungenau erschienen. Den beiden Verfassern des PW fiel demnach ausser der
+Rolle des Lexikographen auch die des Exegeten zu.
+
+<p>Um eine sichere Grundlage für die Wortansätze des Sanskrit zu bekommen, wurde
+als Basis der Wörterbucharbeit die vedische Literatur bearbeitet. Vor allem für
+das jüngere Sanskrit schien ein genaues Studiumdes Veda die Grundlage zu sein,
+insbesondere hinsichtlich der Etymologie. Diese schwierige Aufgabe zu lösen, war
+R. Roth bestimmt, der damit Entscheidendes für die Sanskritphilologie überhaupt
+geleistet hat, vor allem, wenn man bedenkt, dass Vorarbeiten praktisch nicht
+vorlagen. M. Müllers Ausgabe des R2gveda lag noch nicht vor, und Langlois
+Übersetzung des R2gveda schien R. Roth nicht den Anforderungen eines solch
+schwierigen Textes gewachsen zu sein. So blieben doch in vielen [pwj3] Fällen
+als Hilfe nur die einheimischen Kommentatoren übrig, die wohl zur Erklärung von
+Theologie und Kultus viel zum Verständnis beitrugen, die jedoch einst bei der
+Interpretation der alten Lieder des R2gveda vor demselben Problem standen wie
+die europäischen Forsder. Letztere hatten jedoch durch die klassische Philologie
+und durch das Aufkommen der historisch vergleichenden Sprachwissenschaft
+besonders günstige Ausgangsbedingungen. Im Gegensatz zu H.H. Wilson glaubte R.
+Roth nicht, dass Sa1yan2a zur Interpretation des R2gveda mehr beitragen könne
+als ein europäischer Philologe. Er war deshalb gezwungen, in allen
+Zweifelsfällen selbständig Wortsinn und -bedeutung herauszufinden.
+
+<p>All dies musste -- mangels adäquater Ausgaben -- aus Handschriften erfolgen, und
+es zeigte sich hier ein neues Problem, dem R. Roth und O. Böhtlingk
+gegenüberstanden. Hatten sie bisher schon die Doppelrolle des Lexikographen und
+des Interpreten inne, wäre nun noch die Rolle des Texteditors auf sie
+zugekommen, eine Arbeit, die nicht mehr zu bewältigen war. Denn zum einen waren
+um die Mitte des vorigen Jahrhunderts noch längst nicht alle Werke der
+Sanskritliteratur bekannt, man denke nur an die Dramen Bha1sas, die erst 1910
+von Gan2apati s4a1stri1 auf einer Palmblatthandschrift in Südindien gefunden
+wurden, oder man denke an As4vaghos4a, dessen erstes Kapitel aus dem
+Buddhacarita erst 1892 von Sylvain Le4vi veröffentlicht wurde. Zum anderen war
+auch die Zahl der philologisch überprüften Ausgaben noch sehr begrenzt. Vielfach
+konnten nur Handschriften herangezogen werden, die dann gegebenenfalls in den
+weiteren Bänden des PW und des pw durch edierte Texte ersetzt wurden z.B. die
+Ka1dambari1, das Gobhilagr2hyasu1tra, das Ha1sya1rn2ava usw. Manchmal waren die
+bereits vorhandenen Neuausgaben durch bessere zu ersetzen wie bei der
+Ra1jataran3gin2i1. Die Sprüche des Bhartr2hari und die des Pan5catantra
+beispielsweise schienen O. Böhtlingk zwar in hohem Mass wert zu sein, in das
+Wörterbuch mitaufgenommen zu werden, sie waren jedoch noch nicht kritisch
+bearbeitet worden. Dies veranlasste ihn dann übrigens zur Arbeit an seinen
+indischen Sprüchen, die zum grossen Teil auf denen des Bhartr2hari fussen, wie
+man es dem Vorwort des 3. Bandes des PW entnehmen kann.
+
+<p>Auch viele andere Ausgaben wichtiger Werke lagen noch nicht in kritischer
+Edition vor wie die des Maha1bha1rata, dessen kritische [pwj4] Edition
+bekanntlich zwischen 1933-1966 in Poona erschien. Auch die kritische Ausgabe des
+Ra1ma1yan2a wurde erst 1933 begonnen. Insgesamt gesehen bestand doch wohl für
+die Arbeit an diesem Thesaurus der Sanskritsprache eine prekäre Situation in
+Bezug auf Anzahl und Art der Textausgaben. Trotzdem nahmen R. Roth und O.
+Böhtlingk das Werk in Angriff und führten es zu einem im Grunde doch wohl sehr
+erfolgreichen Abschluss.
+
+<p>Zwischen den Jahren 1879-1889 erschien dann im Auftrag der Kaiserlichen Akademie
+der Wissenschaften zu St. Petersburg die kürzere Fassung des PW, eine Ausgabe,
+bei der O. Böhtlingk die Herausgabe übernahm. An der Fertigstellung des pw
+nahmen zahlreiche Gelehrte teil, vor allem R. Roth und H. Kern. Es sollte ein
+Wörterbuch für den Anfänger und den praktischen Gebrauch sein. Es war aber nicht
+daran zu denken, von den Herausgebern des PW ein völlig neues grosses Lexikon zu
+erwarten, ausserdem war O. Böhtlingk bereits 64 Jahre alt, als der erste Teil
+des PW erschien, und R. Roth war 58 Jahre alt. Die Grundlage blieb also das PW,
+welches dadurch gekürzt werden konnte, dass man sämtliche im PW zitierten
+Textstellen ausliess und man somit das PW als wichtigste Informationsquelle im
+Vordergrund liess. Durch zahlreiche Stellenverbesserungen und durch die Aufnahme
+neu edierter Texte konnte das pw an vielen Stellen bereichert werden. Die
+Bearbeitung neu edierter Texte geschah jedoch nicht mit derselben
+Ausführlichkeit wie im PW nach O. Böhtlingks Bericht in seinem Vorwort.
+Lediglich Neues wurde hinzugefügt, Nachträge wurden regelmässig eingearbeitet.
+Das pw war als sinnvolle Ergänzung zum PW gedacht, handlicher, preiswerter und
+als eine Gelegenheit für Verbesserungen. Es handelt sich hierbei nicht um einen
+Auszug aus dem PW.
+
+<p>1872 erschien in Oxford das Sanskrit-Englisch-Lexikon von Monier-Williams,
+nachdem ein Jahr zuvor der sechste Band des PW erschienen war. Zu dieser Zeit
+war das alte Sanskrit-Englisch-Lexikon von H.H. Wilson wohl kaum noch zu
+bekommen und die Forderungen des PW waren für englischsprachige
+Sanskritphilologen im allgemeinen zu gross geworden. Diesem Notstand kam
+Monier-Williams nach. Die Hauptgrundlage seiner Arbeit war wohl das PW, wie er
+selber meinte: <i>"... I have always considered an appeal to the St. Petersburg
+Wörterbuch as the most satisfactory available means for [pwj5] deciding
+doubtful questions."</i> Monier-Williams scheint sich an vielen Stellen jedoch zu
+sehr an das PW gehalten zu haben, was ihm dann O. Böhtlingk in seinem Vorwort
+zum pw zum bitteren Vorwurf gemacht hat. Böhtlingk weist ihm nach, dass er an
+vielen Stellen den deutschen Text nur ins Englische übersetzt hat, ohne den
+Originaltext zu konsultieren. Im PW steht z. B. <i>"dyuka = Eule und dyuka1ri =
+Krähe. Bei Wilson fehlerhaft für dyu1ka, dyu1ka1ri."</i> Bei Monier-Williams liest
+man: "dyuka = an owl, dyuka1ri (ka-ari) = the owl's enemy, a crow (wrong forms
+of dyu1ka and dyu1ka1ri)." Die im PW angegebenen Stellen sind jedoch
+Druckfehler. Es müsste eigentlich heissen: dhu1ka und dhu1ka1ri. M.-W. hat hier
+sogar die Druckfehler übernommen. Ein anderes Beispiel ist PW divitmant, am
+Himmel, zum Himmel gehend, himmlisch. M.-W. übersetzt: going in or to the sky,
+heavenly. Aus den anderen Stellen des PW zu div geht hervor, dass es sich hier
+nur um den irdischen Luftraum als Himmel handelt. Heaven wäre aber im Deutschen
+das Paradies.
+
+<p>Sieht man von den Umständen des Zustandekommens dieses Werkes ab, ist gewiss des
+Lexikon von M.-W. in vieler Hinsicht eine nützliche Ergänzung zu den
+Petersburger Wörterbüchern, einmal, da es die Wörter abfolgemässig anders
+bringt, zum anderen, weil es die zusammengesetzten Formen bringt -- z.B. die des
+Verbums als feste, selbständige Artikel, so dass man nicht immer erst die Wurzel
+aufsuchen muss. Da es in Englisch ist, bietet es den nicht der deutschen Sprache
+Mächtigen eine nützliche Übersetzungshilfe.
+
+<p>1887 erschien in Strassburg das Sanskritwörterbuch von Carl Cappeller. Er zeight
+hier eine neue Konzeption in der Sanskritlexikographie. Die bisher vorgestellten
+Wörterbücher hatten einen durchaus enzyklopädischen charakter, d.h. sie wollten
+dem Benutzer die Möglichkeit bieten, sämtliche Bedeutungen eines Sanskritwortes,
+wie sie in der gesamten Literatur Indiens vorkommen, in einem Werk finden zu
+lassen. Jedoch schon O. Böhtlingk beabsichtigte, zu seiner Chresthomathie ein
+Spezialglossar herauszugeben, wozu er nicht gekommen ist. Diese Idee, ein
+Spezialwörterbuch zu einem ganz begrenzten Teil der Sanskritliteratur
+herauszugeben, setzte C. Cappeller in die Tat um. Als Textvorlage benutzte er
+die Chresthomathie von O. Böhtlingk, die 70 Lieder aus dem R2gveda von Geldner
+und Kaegi, [pwj6] die 12 Hymnen des R2gveda von Windischmann, Teile aus dem
+S4atapathabra1hman2a, Episches und die Werke des Ka1lida1sa. Das Wörterbuch
+wurde somit handlich und für den Anfänger gut benutzbar. Cappeller nahm aber
+zusätzlich noch sämtliche belegbaren Wurzeln und "primitiven" Wörter mit
+gesicherter Bedeutung hinzu, weiter eine Fülle von Wörtern, die ihm selbst als
+nützlich erschienen, sodass damit das Werk eine gewisse inhaltliche Abrundung
+erhielt und auch für den allgemeinen praktischen Gebrauch von Nutzen war. Obwohl
+er auf dem Titelblatt schreibt, nach den Petersburger Wörterbüchern gearbeitet
+zu haben, scheint er doch viel Eigeninitiative investiert haben zu müssen, da er
+angibt, keine Kommentare benutzt und jedes Wort nach seiner Bedeutung im Text
+übersetzt zu haben. Cappellers Leistung wird niemand unterschätzen: 1891 folgte
+in Jena die enlische Fassung seines Wörterbuches, was nun um folgende Werke
+erweitert wurde: die Marut-Hymnen von F.M. Müller, die Kat2hopanisad, Manu, die
+Bhagavadgi1ta1,Hitopades4a, Meghadu1ta, Mr2cchakatika, Ma1lati1ma1dhava. Es
+finden sich in diesem Wörterbuch auch aus dem Pra1krit ins Sanskrit übersetzte
+Wörter, die in den Petersburger Wörterbüchern nicht berücksichtigt wurden. Somit
+ist dieses Lexikon auch für englische Sanskritisten von Interesse.
+
+<p>1890 erschien in Poona "The Practical Sanskrit-English Dictionary" von Va1man
+S4ivara1m Apte. Es liegt in drei Bänden vor. Er beabsichtigte, für den Studenten
+ein enzyklopädisches, preislich günstiges Lexikon herzustellen. Wie aus seinem
+Vorwort hervorgeht, lagen ihm dabei als wertvolle Hilfen vor, das Va1caspatyam
+von Ta1ra1na1tha Ta1rkava1caspati, Monier-Williams Lexikon und das grosse
+Petersburger Wörterbuch. Da es als praktisches Werk gedacht war, fügte er den
+Übersetzungen oft noch speziellere Erklärungen an, etwa aus der Mythologie.
+Betont wurden auch einige Erklärungen zu diversen S4a1stras wie Nya1ya,
+Veda1nta, Grammatik oder Poetik. In drei Appendices gibt er noch Informationen
+über die gebräuchlichen Metren, Daten zur Literaturgeschichte und über alte
+geographische Namen.
+
+<p>Dazu eine Kurzfassung ist "The Students's Sanskrit-English Dictionary" in einem
+Band, Poona, 1890. [pwj7]
+
+<p>Das Hauptgewicht der Sanskritlexikographie beruht somit bis heute auf dem
+Sanskritthesaurus von R. Roth und O. Böhtlingk, einem Werk, was mittlerweile
+fast 100 Jahre der Offentlichkeit vorliegt. Viele neuere Arbeiten haben seitdem
+in der Sanskritphilologie neue Problemstandpunkte erbracht. Z.B. gibt es seitdem
+neue oder verbesserte Textausgaben wie etwa die der Ra1jataranin2i1 von M.A.
+Stein, oder die kritische Ausgabe des Maha1bha1rata aus Poona. Vor allem wurden
+zu vielen Einzelproblemen wichtigste Forschungsergebnisse publiziert. Ein
+Beispiel: Dohad2a wird im PW und pw aus Daurhada abgeleitet und erklärt: Es ist
+das Gelüste schwangerer Frauen nach bestimmten Dingen, ein heftiges Verlangen
+überhaupt. M.-W., Cappeller und Apte schliessen sich dieser Interpretation an.
+Lüders legte aber überzeugend dar, dass Dohad2a aus Dvihr2d abgeleitet werden
+muss, d.h. vom Herzen der Mutter und des Kindes: Der Garbha im 4. Monat hat
+Verlangen nach Sinnesgenüssen, deshalb muss der Wunsch der Mutter erfüllt
+werden, damit das Kind keinen Schaden erleidet.
+
+<p>Bei der Interpretation vieler Werke der Sanskritliteratur steht man auch heute
+trotz der immensen lexikologischen Arbeiten des vorigen Jahrhunderts oft noch
+ratlos, dar, man erinnere sich nur an die Problematik botanischer Namen. Auch
+bei der Übersetzung moderner Sanskrittexte wie der Gandhibiographie von
+Satyas4odhana erweisen such gelegentlich die klassischen Wörterbücher als
+ungünstig. Die Anfertigung von Spezialwörterbüchern zu einem bestimmten Text
+oder zu einer bestimmten Literaturepoche käme daher heutigen Literaturstudian
+entgegen. Denn auch bei Cappeller finden sich als Grundlage Texte aus ganz
+verschiedenen Zeitabschnitten. Gerade der student oder der eilige Benutzer
+wünschen sich ein Wörterbuch mit nicht zuviel und nicht zu wenig Angaben zu den
+einzelnen Wörtern. Der Wortschatz könnte auf die Epoche beschränkt sein, die
+einen gerade beschäftigt. Allerdings erfordert dies eine hohe Verantwortung des
+verfassers, da man in diesem Fall unbedingt auf die Zuverlässigkeit der
+Übersetzung angewiesen ist.
+
+<p>Liessen die bisherigen Bemerkungen zur Entwicklung der wichtigsten Wörterbücher
+die allgemeine Situation der Sanskritlexikographie erkennen, so dürften dazu
+wohl die folgenden ergänzenden Worte angebracht erscheinen. [pwj8]
+
+<h1>II.
+
+<p>Wie bereits oben erwähnt wurde, darf zunächst festgestellt werden, dass die
+zeitlich nach dem PW und pw erschienen Sanskritwörterbücher hinsichtlich der
+Textauswahl nicht mehr wesentlich bereichert worden sind, was vielleicht
+grundsätzlich nicht weiter ins Gewicht fallen mag. Bei M.-W. finden sich
+folgende in den Petersburger Wöterbüchern nicht aufgelistete Texte, bei denen
+keine weitere Identifikation möglich ist:
+
+<table> <cell>A1ca1ranirn2aya <cell>Agastya Sam2hita1 <cell>Alam2ka1rakaustubha
+<cell>Alam2ka1rasarvasva <cell>(Mankhaka) <cell>Ananta Sam2hita1 <cell>A1s2t2a1n4gahr2daya
+<cell>As2t2a1vakra Sam3hita1 <cell>A1s4vala1yana S4a1khokta1 s. Mantra Sam2hita1
+<cell>Atharvas4ikha Up. <cell>Bhakta1mara Stotra <cell>Bha1rati1ti1rtha's Pan5chdas4i1
+<cell>Bha1s4ika Su1tra <cell>Brahmvidya1 Up. <cell>Br2hanna1rdi1ya P. <cell>Buddhacarita
+<cell>Can2d2akaus4ika <cell>Caran2avyu1ha <cell>Chandah Su1tra <cell>Da1t2ha1dha1tuvam2s4a
+<cell>Da1yatattva <cell>Dharmasam2graha <cell>Dharmaviveka <cell>Durga1vila1sa
+<cell>Du1ta1n3gada <cell>Gan2es4a P. <cell>Ga1rgi1 Sam2hita1 <cell>Ga1tha1sam2graha
+<cell>Gauragan2oddes4a <cell>Gaya1 Ma1ha1tmya <cell>Goraks2a S4ataka <cell>Grahayajn5atattva
+<cell>Haravijaya <cell>Ha1yanaratna <cell>Hiranyakes4in Gr2hya-und Phit2-Su1tra <cell>Indian
+Wisdom von M.--W. <cell>Kalki P. <cell>Kalpataru <cell>Kalya1n2amandira Stotra
+<cell>Kautukasarvasva <cell>Kavikalpala1ta <cell>Kavikalpataru <cell>Ka1vyadars4a
+<cell>Kramadi1pika1 <cell>Kr2s2n2karn2a1mr2ta <cell>Kuladi1pika1 <cell>Kut2t2ani1mata
+<cell>tLan3ka1vata1ra Su1tra <cell>Mallapraka1s4a <cell>mantramahodadhi <cell>Mathura1
+Ma1ha1tmya <cell>Muktika1 Up. <cell>Nalacampu <cell>Nandi P. <cell>Na1radi1ya P.
+<cell>Narasim2ha P. <cell>Ni1lamata P. <cell>Nya1yama1lavistara <cell>Padma P.
+<cell>Padyasam2graha <cell>Pa1pabuddhidharmabuddhikatha1naka <cell>Paras4ura1ma Praka1s4a
+<cell>Pa1rvati1parin2aya <cell>Phetkarin2i1 Tantra <cell>Pradyumnavijaya
+<cell>Pra1n2a1gnihotra Up. <cell>Prasan3ga1bharan2a <cell>Ra1ghavapa1n2d2avi1ya
+<cell>Ra1magi1ta1 <cell>Ra1mapu1ja1saran2i <cell>Ra1ma Up. <cell>Ra1sali1la
+<cell>Rasataran3gin2i1 <cell>Rasendracinta1mam2i <cell>Rasikaraman2a <cell>Ratirahasya
+<cell>Religious Thought etc. <cell>(M.-W.) <cell>Rava1 Khan2d2a <cell>Romakasiddha1nta
+<cell>Rudraya1mala <cell>S4aktiratna1kara <cell>S4am2bhalagra1ma Ma1ha1tmya
+<cell>S4a1ntikalpa <cell>S4a1rada1tilaka <cell>Saura P. <cell>S2adgurus4is2ya
+<cell>s4iks2a1pattri1 <cell>Sim2ha1sanadva1trim2s4ika1 <cell>S4ira Up. <cell>Smr2tikaumudi1
+<cell>Smr2titattva <cell>S4ri1ma1la Ma1ha1tmya <cell>Subha1s2ita1vali1
+<cell>Su1ryaprajn5apti <cell>Tod2ara1nanda <cell>Upa P. <cell>Utkala Khan2d2a
+<cell>Uttamacaritrakatha1naka <cell>Vahni P. <cell>Va1ra1hi1tantra <cell>Vasantara1ja's
+S4a1kuna <cell>Veda1ntaparibha1s2a <cell>Vi1racarita <cell>Vyavaha1ratattva
+<cell>Yogavasis2t2hasa1ra </table>
+
+<p>Viel bedenklicher mag scheinen, dass Gleiches auch in Hinsicht auf die
+Wortansätze gelten dürfte. D.h., die heutige Sanskritlexikographie stützt sich
+weitgehend auf die Arbeit von zwei Forschern, R. Roth und O. Böhtlingk, die das
+Ergebnis ihrer Studien schon vor mehr als hundert Jahren veröffentlichten. Wie
+seinerzeit die Pionierarbeit von Wilson durch die gewaltige Leistung von Roth
+und Böhtlingk abzulösen war, so wäre es demnach wohl heute erforderlich, das PW
+und dessen unmittelbare Nachfolger durch ein von Grund auf neues Lexikon zu
+ersetzen. Der heutige Sanskritphilologe befindet sich in einer eigenartigen
+Situation: Für die Übersetzung und Interpretation ist er meist auf die bisher
+erwähnten Wörterbücher angewiesen, d.h., er ist oft darauf angewiesen, was
+damals Roth und Böhtlingk für die Ansetzung eines Wortes für richtig hielten.
+Doch sind in diesem Jahrhundert in der Indologie so viele und überaus wichtige
+[pwj10] Erkenntnisse zu zentralen Problemen der indischen Geisteswelt gewonnen
+worden, dass dadurch viele Vorstellungen des vergangenen Jahrhunderts überholt
+sein dürften. Man denke hier beispielsweise an die modernen Einblicke in die
+vedische Sprach- und Kulturwelt, deren Bedeutung für das indische Geistesleben
+wohl nicht überschäzt werden kann. Entscheidende Erkenntnisse gingen hier von H.
+Lüders und P. Thieme mit der Aufhellung der Magievorstellungen und der alten
+Religion aus, -- in Indien stets von grösstem Einfluss auf die literarischen
+Kräfte. Die unvorstellbar umfangreichen Ergebnisse der vielen monographischen
+Sonderstudien oder der Beiträge in Periodica verlangen eine verantwortungsvolle
+wie kenntnisreiche Auswertung für ein völlig neues Sanskritwörterbuch. Benutzt
+man nun heute für die Interpretation eines Sanskrittextes das PW und dessen
+Nachfolger, so steht man damit tatsächlich auf dem Boden des 19. Jahrhunderts,
+obwohl ja oftmals viel geeignetere Interpretationsmöglichkeiten zur Verfügung
+stünden.
+
+<p>Es ist deshalb für die Dokumentation der geschilderten Situation der heutigen
+Verhältnisse unbedingt notwendig, sich mit der textlichen Basis des PW vertraut
+zu machen, um die dort bereitgestellten Wortmaterialien und Ansätze besser
+beurteilen zu können. Diese Dokumentation soll in der nachfolgenden Übersicht
+geschehen.
+
+<h1>III.
+
+<p>Sowohl im PW als auch im pw steht zu Anfang eines Bandes jeweils ein Index, in
+dem die Abkürzungen der benutzten Texte aufgeführt wie offesichtlich auch als
+eine Art Bibliographiebehelf gedacht werden. In der vorliegenden Arbeit wird nun
+versucht, nach diesen Indices die benutzten Texte soweit möglich wirksam zu
+erfassen, ferner sollten die bibliographischen Angaben nachgeprüft und
+verzeichnet werden mit Ort und Jahr der Herausgabe und den jeweilgen
+Textausgebern, sofern vorhanden. Hierbei zeigt sich schon nach kurzem Bemühen
+ein Problem, welches zugleich für die schwierige Quellensiuation des PW
+charakteristisch ist, mit der Roth und Böhtlingk zu kämpfen gehabt hatten. Man
+kann zwar mit einiger Mühe in Form eines Zettelsystems aus sämtlichen sich
+bietenden Abkürzungen und Querverweisungen eine vollständige Bibliographierung
+[pwj11] der benutzten Sanskrittexte erreichen, jedoch gibt es leider immer
+wieder auch Kurzangaben ohne jede weiterführende Information, womit einer
+bibliographischen Identifizierung praktisch unlösbare Hindernisse
+entgegengesetzt sind.
+
+<p>Ein Beispiel möge das erläutern: Im Band 1 des PW steht auf Seite 2 der
+Abkürzungsliste: "C11a1n5kh. C11r. = C11a1n5kha1janas C11rautasu1tra1n2i," d.h.
+S4a1n3kha1yanas S4rautasu1tra1n2i. Was nun? Um welche Textausgabe handelt es
+sich hierbei? War der Text damals überhaupt schon einmal herausgegeben worden,
+oder handelte es sich hier nur um eine Handschrift? Nun findet man bei
+gedruckten bearbeiteten Ausgaben sowohl im PW als auch im pw meistens eine
+Angabe über die Provenienz des Textes, es bleibt also wohl zu vermuten, dass es
+sich in dem obigen Fall um Handschrift handeln könnte. Doch welche Handschrift
+könnte es sein? Diese Frage aber muss, obwohl im PW und im pw einige
+Handschriftensammlungen erwähnt werden, offen bleiben, da zu kaum einer
+Handschrift die Herkunft angegeben wird. Wenn man davon ausgeht, dass Texte wie
+der obige im Grunde nicht weiter zu identifizierende Handschriften darstellen,
+muss man sich doch fragen, ob diese Texthandschriften auch vollständig
+vorgelegen haben. Es könnte doch sein, dass bei einer Handschrift, die einen
+Text etwa aus der Philosophie bright, ein oder zwei Su1tras fehlen, die aber für
+das Verständnis jedes Wortes nötig sind.
+
+<p>Leider wissen wir auch nichts über den Erhaltungszustand der benutzten
+Handschriften, weil auch hier sehr oft jede genaue Bibliotheksangabe fehlt.
+
+<p>Ein anderes Problem ist die Anführung von Kommentatoren ohne nähere Angaben, wie
+zum Beispiel: Kommentator zum Tarkasam2graha, und wenn ja, wie wurde er benutzt?
+Wurde sein Kommentar selbst ausgewertet als eigenständiger Text, oder benutzte
+man ihn nur zur Erklärung zweifelhafter Stellen im untersuchten Haupttext? man
+weiss es nicht. Dann ist beispielsweise völlig offen, wie man Werke ausgewertet
+hat wie die tibetische Lebensbeschreibung S4a1kyamunis von A. Schiefner.
+
+<p>Besser ist die Situation bei den Textangaben, hinter denen irgendein Hinweis
+steht, wie z.B. Ort und Jahr der Herausgabe oder der Herausgeber selber. Im PW
+findet man oft eine Nummer in der "Bibliothek [pwj12] Gildemeister," (Gild.)
+von 1847. Solch eine Angabe ist aber gar nicht so unproblematisch für die
+Identifizierung eines Textes, da dieses Buch überall verfügbar ist, und da dort
+auch bibliographisch unsichere Textausgaben angeführt sind. Meistens hat mir bei
+der weiteren Bestimmung eines Textes, dem eine der obigen Angabenbeigefügt war,
+der "India Office Library Catalogu" (I.O.) weitergeholfen. In anderen Fällen
+kann ich auf den Band "Indian Lexicography" von C. Vogel, Wiesbaden, 1979
+verweisen.
+
+<p>Wie sich also zeigt, erlauben gegebenenfalls die ungenügenden Informationen des
+PW keine absolute Vollständigkeit bei der folgenden Bibliographie.
+
+<p>Es bleibt noch das Problem, ob überhaupt die Abkürzungslisten des PW wie des pw
+auch wirklich alle benutzten Texte anführen.
+
+<p>Wie die vorstehenden Ausführungen zeigen, sind zwar undere Sanskritwörterbücher
+letztlich alle vom PW abhängig, dieses aber ist in seiner Quellensitution doch
+recht unsicher.
+
+<h1>IV.
+
+<p>Praktisch bin ich wie folgt vorgegangen: Alle im PW und pw benutzten Angaben
+wurden aufgenommen. Sofern diese in einer alten Umschrift oder verkürzt geboten
+werden, habe ich möglichst vollständige Angaben und zwar in moderner Umschrift
+eingeführt. Zwecks Identifizierbarkeit folgt den Publikationsangaben der Name
+des jeweilgen Textherausgebers, der Ort und das Jahr der Ausgabe, gefolgt ferner
+von der Seitenzahl in: <i>I.O.</i>, oder von der Titelnummer in: "Bibliothek
+Gildemeister", wo die weiteren Angaben zu entnehmen sind. Kommentatorennamen
+waren meist ohne weiteres anzuführen. Gegebenenfalls werden Sanskrittitel durch
+Verfasserangaben ergänzt. Bei jeder Angabe steht, ob sie sich auf das PW oder
+etwa auf das pw bezieht.
+
+<p><b>Abhidha1nacinta1man2i1</b>
+<p>--...Von Hemacandra. Ed. O. Böhtlingk und Ch. Rieu, St. Petersburg, 1847. [I.O. 5] PW, pw [pwj13]
+
+<p><b>A1ca1radars4a</b>
+<p>--...Von S4ri1datta. Ed. Benares, 1821. pw
+
+<p><b>A1cha1ra1n9gasu1tra</b>
+<p>--...Von S4i1lan3ka, Ed. Bombay, 1895. [I.O. 21]pw
+<p>--...Von Sudharmasva1min. Ed. Bombay, 1895. [I.O. 21] pw
+
+<p><b>A1c11v.C11r.</b> s. A1s4vala1yanas4rautasu1tra
+
+<p><b>A1c11v.Gr2hj.</b> s. A1s4vala1yanagr2hyasu1tra
+
+<p><b>Adbh.Br.</b> s. Adbhutabra1hman2a
+
+<p><b>Adbhutabra1hman2a</b>
+<p>--...Ed. A. Weber, Berlin, 1858. [I.O. 27] PW
+
+<p><b>Adbhutas.</b> s. Adbhutasa1ra
+
+<p><b>Adbhutasa1ra</b>
+<p>--...Ohne weiteres im PW.
+
+<p><b>Adhima1sanirn2aya</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>Agni-P.</b> s. Agnipura1n2a
+
+<p><b>Agnipura1n2a</b>
+<p>--...Ed. R. Mitra, Calcutta, 1873-79. [I.O. 53] pw
+
+<p><b>A1hnikat.</b> s. A1hnikatattva
+
+<p><b>A1hnikatattva</b>
+<p>--...Ohne weiteres im PW.
+
+<p><b>Ainslie</b> s. Materia indica
+
+<p><b>Ait.A1r.</b> s. Aitareyaran2yaka
+
+<p><b>Aitareya1ran2yaka</b>
+<p>--...1. Nach Mitteilungen von A. Weber. PW
+<p>--...2. Ed. R. Mitra, (alcutta, 1876. [I.O. 58] pw
+
+<p><b>Aitareyabra1hman2a</b>
+<p>--...1. Handschrift mit Sa1yan2as Kommentar. PW
+<p>--...2. Ed. M. Haug, Bombay, 1863. [I.O. 59] pw [pwj14]
+
+<p><b>Aitareya Upanis2ad</b> s. Taittiri1ya Upanis2ad.
+
+<p><b>Ait.Br.</b> s. Aitareyabra1hman2a
+
+<p><b>Ait.Up.</b> s. Aitareya Upanis2ad
+
+<p><b>AK.</b> s. Amarakos2a
+
+<p><b>Akademische Vorlesungen</b>
+<p>--...Von A. Weber, Berlin, 1852. PW; 1876. pw
+
+<p><b>Alam2ka1raratna1kara</b>
+<p>--...Von S4obha1kara. Deccan Collection, Handschrift Nr. 227. pw
+
+<p><b>Alam2ka1rasarvasva</b>
+<p>--...Von Ruyyaka. Deccan Collection, Handschrift Nr. 231. pw
+
+<p><b>Alam2ka1ras4ekhara</b>
+<p>--...Von Kes4avamis4ra. Lith. Ausgabe Benares, 1833. pw
+
+<p><b>Alam2ka1ratilaka</b>
+<p>--...Handschrift. pw
+
+<p><b>Alam2ka1ravimars4in2i1</b>
+<p>--...Von Jayaratha. Deccan Collection, Handschrift Nr. 230. pw
+
+<p><b>Algebra</b>
+<p>--...Von H. T. Colebrooke, London, 1817. [I.O. 75] PW, pw
+
+<p><b>Amarad.</b> s. Amaradatta
+
+<p><b>Amaradatta</b>
+<p>--...Ein Lexikograph. [Vogel 321, 347, 348] PW
+
+<p><b>Amarakos4a</b>
+<p>--...1. Ed. H. T. Colebrooke, Serampore, 1808. 1825. [I.O. 1698] PW
+<p>--...2. Ed. A. L. Deslongchamps, Paris, 1839-45. [I.O. 1699] PW, pw
+
+<p><b>Amarus4ataka</b>
+<p>--...Ed. Calcutta, 1808. [Gild. 162] PW Mit Ghat2akarpara.
+
+<p><b>Amr2tavindu1panis2ad</b> s. Atharvan2a Upanis2ads
+
+<p><b>Amr2tav.Up.</b> s. Amr2tavindu1panis2ad
+
+<p><b>an.</b> s. Aneka1rthasam2graha
+
+<p><b>A1andag.</b> s. A1nandagiri
+
+<p><b>A1nandagiri</b>
+<p>--...Ein Kommentator der Br2hada1ran2yaka Upanis2ad. PW, pw
+
+<p><b>A1nandal.</b> s. A1nandalahari1
+
+<p><b>A1nandalahari1</b> s. Ka1vyasam2graha
+
+<p><b>A1nandav.</b> s. A1nandavalli1
+
+<p><b>A1nandavalli1 (Brahmavalli1)</b>
+<p>--...Zur Taittiri1ya Upanis2ad [I.O. 107] PW
+
+<p><b>Anarghara1ghava</b>
+<p>--...Ed. Premachandra Tarkava1gi1s4a, Calcutta, 1860. [I.O. 119] pw [pwj15]
+
+<p><b>Aneka1rthadhv.</b> s. Aneka1rthadhvaniman5jari1
+
+<p><b>Aneka1rthadhvaniman5jari1</b>
+<p>--...Ein Wörterbuch, aufgeführt im S4KD. [Vogel 319] PW
+
+<p><b>Aneka1rthasam2graha</b>
+<p>--...Von Hemacandra. Ed. H. T. Colebrooke, Calcutta, 1807. [Gild. 259]PW, pw
+
+<p><b>Aneka1rthasamuccaya</b>
+<p>--...Von S4a1s4vata. Ed. Th. Zachariae, Berlin, 1882. [I.O. 121]pw
+
+<p><b>Anh.</b> = Anhang
+
+<p><b>Annam2bh.</b> s. Annam2bhat2t2a
+
+<p><b>Annam2bhat2t2a</b>
+<p>--...Zum Tarkasam2graha. [I.O. 2713] PW
+
+<p><b>Anthologia sanscritica</b>
+<p>--...Von Chr. Lassen, Bonn, 1838. 1868. [I.O. 121] PW, pw Mit Brahmapura1n2a,
+S4ukasaptati1, Dhu1rtasama1gama, Veta1lapan5caim2s4atika1, Ca1n2d2u1pa1khya1na
+
+<p><b>Anukr.</b> = Anukraman2ika1
+
+<p><b>Anup.s.</b> s. Anupadasu1tra
+
+<p><b>Anupadasu1tra</b>
+<p>--...Ohne weiteres im PW.
+
+<p><b>Apara1rka</b>
+<p>--...Zur Ya1jn5avalkyasmr2ti. [I.O. 31000] pw
+
+<p><b>A1past.</b> s. A1pastamba
+
+<p><b>A1pastamba</b> The Aphorisms of the sacred Law of the Hindoos by
+A1pastamba. Ed. G. Bühler, Bombay, 1868-71. [I.O. 143] PW, pw
+
+<p><b>A1pastamba S4rautasu1tra</b>
+<p>--...Handschrift. pw
+
+<p><b>A1past.C11r.</b> s. A1pastamba S4rautasu1tra
+
+<p><b>Archaeological Survey</b>
+<p>--...of India, pw
+
+<p><b>Ar4g.</b> s. Arjunasama1gama
+
+<p><b>A1rjav.</b> s. A1ryavidya1sudha1kara
+
+<p><b>Arjunasama1gama</b>
+<p>--...Liber sine titulo. Ed. F. Bopp, Berlin, 1829. [Gild. 106] PW, pw Mit
+Matsyopa1khya1nam, Draupadi1haran2am (Draupadi1prama1tha), Arjunasama1gama,
+Sa1vitri1
+
+<p><b>A1rsh.Br.</b> s. A1rs2eyabra1hman2a
+
+<p><b>A1rs2eyabra1hman2a</b>
+<p>--...Ed. A. C. Burnell, Mangalore, 1876. [I.O. 162] pw [pwj16]
+
+<p><b>A1run2eya Upanis2ad</b> s. Atharvan2a Upanis2ads
+
+<p><b>A1run2ika Upanis2ad</b>
+<p>--...Ohne weiteres im PW.
+
+<p><b>A1run2.Up.</b> s. A1run2eya Upanis2ad und A1run2ika Upanis2ad
+
+<p><b>A1ryabhat2t2i1ya</b>
+<p>--...Ed. H. Kern, Leyden, 1874. [I.O. 169] pw
+
+<p><b>A1ryaman5jus4ri1na1masan2gi1 ti1</b>
+<p>--...Im Verzeichnis der Petersburger Sanskrithandschriften Nr. 121. PW
+
+<p><b>A1ryavidya1sudha1kara</b>
+<p>--...Ed. Cimana Bhat2t2a, Bombay, 1868. [I.O. 175] pw
+
+<p><b>Asaha1ya</b>
+<p>--...Ein Kommentator des Narada. pw
+
+<p><b>As.</b> s. Asiatic Researches
+
+<p><b>Asiatic Researches</b>
+<p>--...or Transactions of the Society instituted in Bengal, for inquiring into
+the History and Antiquities, the Arts, Sceince, and Literature of Asia, London.
+PW
+
+<p><b>A1s4vala1yana Gr2hyasu1t4a</b>
+<p>--...1. Handschrift in 4 Adhya1ya. PW
+<p>--...2. Ed. A. F. Stenzler, Leipzig, 1864-65. [I.O. 204] pw
+
+<p><b>A1s4vala1yana S4rautasu1tra</b>
+<p>--...1. Handschrift in 4 Adhya1ya. PW
+<p>--...2. Ed. R. Vidya1ratna, Calcutta. 1864-75. [I.O. 207] pw
+
+<p><b>Atharvan2a Upanis2ads</b>
+<p>--...Ed. R. Tarkaratna, Calcutta, 1872-74. [I.O. 2811] PW, pw Mit
+Amr2tavindu1panis2ad, A1tma Up., A1run2eya Up., Brahmabindu1panis2ad, Brahma
+Up., Cu1lika Up., Dhya1nabindu1panis2ad, Garbha Up., Garud2a Up., Ham2sa Up.,
+Hanumaduktara1ma up., Ja1ba1la Up.,
+Yogatattva Up., Kaivalya Up., Kan2t2has4ruti Up., Kaus4i1taki1bra1hman2a
+Up., Tejobindu1panis2ad, Ks2urika Up., Na1gabindu1panis2ad, samn5a1sa Up.,
+Ni1larudra Up., Nr2sim2hata1pani1ya Up., Pin2d2a Up., Ra1mapu1rvata1pani1ya
+Up., Sarvopanis2adsa1ra, S4iva Up., Yogas4ikha Up., Yogatattva Up.
+
+<p><b>Atharvaveda</b>
+<p>--...Ed. R. Roth und D. Whitney, Berlin, 1855. [I.O. 213] PW, pw Mit Anukraman2ika1 (10 Pat2ala),
+Pra1tis4a1khya, Pra1yas4citta und Paris4is2t2a als Handschrift.
+
+<p><b>Atharvaveda der Paippala1da-Schule</b>
+<p>--...Handschrift. pw [pwj17]
+
+<p><b>A1tma Upanis2ad</b> s. Atharvan2a Upanis2ada
+
+<p><b>A1tmop.</b> s. A1tma Upanis2ad
+
+<p><b>Aucitya1lam2ka1ra</b>
+<p>--...Ohne weiteres im pw
+
+<p><b>Aupapa1tikasu1tra</b>
+<p>--...Ed. L. Leumann, Leipzig, 1883. [I.O. 238] pw
+
+<p><b>AV.</b> s. Atharvaveda
+
+<p><b>Avada1nas4ataka</b>
+<p>--...Eine buddhistische Legendensammlung. PW
+
+<p><b>Avad.C11at.</b> s. Avada1nas4ataka
+
+<p><b>AV.Anukr.</b> s. Atharvaveda
+
+<p><b>AV.Gjot.</b> s. Jyotis2a zum Atharvaveda
+
+<p><b>avj.</b> = avyaya (zum Medini1kos4a)
+
+<p><b>AV. Paipp.</b> s. Atharvaveda der Paippala1da Schule
+
+<p><b>AV. Paric11.</b> s. Atharvaveda
+
+<p><b>AV.Pra1jac11k4.</b> s. Atharvaveda
+
+<p><b>AV.Pra1t.</b> s. Atharvaveda
+
+<p><b>Avyaya1neka1rthavarga</b> s. Medini1kos4a
+
+<p><b>Ba1dar.</b> s. Ba1dara1yan2a
+
+<p><b>Ba1dara1yan2a</b> s. Brahmasu1tra
+
+<p><b>B. A. J.</b> = Bombay Asiatic Journal pw
+
+<p><b>Ba1labodhani1</b> s. S4am2kara
+
+<p><b>Ba1lar.</b> s. Ba1ara1ma1yan2a
+
+<p><b>Ba1lara1ma1yan2a</b>
+<p>--...Ed. G. S4a1stri1, Benares, 1869. [I.O. 269] pw
+
+<p><b>Baudh.</b> s. Baudha1yana
+
+<p><b>Baudha1yana</b>
+<p>--...Eine Schule zum schwarzen Yajurveda. Nach Zitaten in anderen Werken und
+nach Mitteilungen von G. Bühler. PW, pw
+
+<p><b>Benf.Chr.</b> s. Handbuch der Snskritsprache
+
+<p><b>Benf.Gr.</b> s. Handbuch der Sanskritsprache
+
+<p><b>Berichte d.k.s.Ges.d.Ww.</b> = Berichte der königlich sächsischen
+Gesellschaft der Wissenschaften. PW
+
+<p><b>Berlin:</b> Verzeichnis von Sanskrithandschriften von A. Weber.
+
+<p><b>Berl.Mon.</b> s. Monatsbericht
+
+<p><b>Bhadraba1hucarita</b>
+<p>--...Ed. H. Jacobi, in: Z. d. d. m. G. 38, 19ff. pw [pwj18]
+
+<p><b>Bhag.</b> s. Bhagavadgi1ta1
+
+<p><b>Bhagana1dya1ya</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>Bhagavadgi1ta1</b>
+<p>--...Ed. A. Schlegel, Bonn, 1846. [Gild. 116] PW, pw
+
+<p><b>Bha1gavatapura1n2a</b>
+<p>--...Ed. E. Burnouf, Paris, 1840-44. <i>I.O. 359] PW, pw 9Skandha von U1ran
+zitiert. Ausserdem nach Anführungen im Vp. und S4KD. Zusätzlich im pw unbekannte
+Bombayer Ausgabe.
+
+<p><b>Bhagavati1</b>
+<p>--...Ed. A. Weber, Berlin, 1866. [I.O. 2777] pw
+
+<p><b>Bha1g.P.</b> s. Bha1gavatapura1n2a
+
+<p><b>4Bha1m.</b> s. Bha1mati1
+
+<p><b>Bha1mati1</b>
+<p>--...Ed. Ba1las4a1stri1, 1876-80. [I.O. 521] pw
+
+<p><b>Bha1mini1vila1sa</b>
+<p>--...Ed. A. Bergaigne, Paris, 1872. [I.O. 400] pw
+
+<p><b>Bha1m.V.</b> s. Bha1mini1vila1sa
+
+<p><b>Bha1nud.</b> s. Bha1nudi1ks2ita
+
+<p><b>Bha1nudi1ks2ita</b>
+<p>--...Ein Kommentator des Amarakos4a. PW
+
+<p><b>Bhar.</b> s. Bharata
+
+<p><b>Bharata</b>
+<p>--...Ein Autor über Schauspielkunst. Handschrift? PW
+
+<p><b>Bharat2akadvatr2m2s4ika1</b>
+<p>--...Handschrift. pw
+
+<p><b>Bha1rati1yana1t2yas4a1stra</b>
+<p>--...In Halls Das4aru1pa am Ende. pw
+
+<p><b>Bha1r.Na1t2jac11.</b> s. Bha1rati1yana1t2yas4a1stra
+
+<p><b>Bhartr2.</b> s. Bhartr2hari
+
+<p><b>Bhartr2hari</b>
+<p>--...Ed. P. A. Bohlen, Berlin, 1833[Gild. 156]PW,pw Mit
+Cauri1suratapan5cas4ikha1.
+
+<p><b>Bha1s2apariccheda</b>
+<p>--...Ed. E. Röer, Calcutta, 1850. [I.O. 422] PW, pw
+
+<p><b>Bha1s2ap.</b> s. Bha1s2apariccheda
+
+<p><b>Bha1skara</b> s. Siddha1ntas4iroman2i und Li1la1vati1 [pwj19]
+
+<p><b>Bhat2t2.</b> s. Bhat2t2ika1vya
+
+<p><b>Bhat2t2ika1vya</b>
+<p>--...Ed. Calcutta, 1828. [I.O. 2165] PW, pw
+
+<p><b>Bha1vapr.</b> s. Bha1vapraka1s4a
+
+<p><b>Bha1vapraka1s4a</b>
+<p>--...1. Nach Anführungen im S4KD. PW
+<p>--...2. J. Vidya1sa1gara, Calcutta, 1875. [I.O. 438] pw
+<p>--...3. Handschrift. pw
+
+<p><b>Bhavishjott.</b> s. Bhavis2yottama Pura1n2a
+
+<p><b>Bhavis2yapura1n2a</b>
+<p>--...Handschrift. PW, pw
+
+<p><b>Bhavis2yottama Pura1n2a</b>
+<p>--...Nach Zitaten in anderen Werken and nach Mitteilungen von Th. Aufrecht. pw
+
+<p><b>Bhav.Pur.</b> s. Bhavis2yapura1n2a
+
+<p><b>Bhog4a K.</b> s. Bhojacarita
+
+<p><b>Bhojacarita</b>
+<p>--...Ed. Madras, 1862. pw
+
+<p><b>Bhojaprabandha</b>
+<p>--...Ed. Benares, 1868. [I.O. 449] pw
+
+<p><b>Bhu1ripr.</b> s. Bhu1riprayoga
+
+<p><b>Bhu1riprayo1ga</b>
+<p>--...Ein Wörterbuch nach Anführungen im S4KD. PW
+
+<p><b>Bibl.ind.</b> = Bibliotheca indica
+
+<p><b>Bibliotheca sanscrita</b>
+<p>--...Von Johannes Gildemeister, Bonn, 1847. PW, pw
+
+<p><b>Bi1g4ag.</b> s. Bi1jagan2ita
+
+<p><b>Bi1jagan2ita</b> s. Li1la1vati1
+
+<p><b>Böhtlingk, Sanskrit Chresthomathie</b> s. Sanrkrit Chresthomathie
+
+<p><b>Bra1hmabindu1p.</b> s. Bra1hmabindu1panis2ad
+
+<p><b>Bra1hmabindu1panis2ad</b> s. Atharvan2a Upanis2ads
+
+<p><b>Bra1hman.</b> s. Bra1hman2avila1pa
+
+<p><b>Bra1hman2avila1pa</b> s. Indraloka1gamana
+
+<p><b>Bra1hma1n2d2a P.</b> s. Bra1hma1n2d2a Pura1n2a
+
+<p><b>Bra1hma1n2d2a Pura1n2a</b>
+<p>--...Ohne weiteres im PW
+
+<p><b>Brahma P.</b> s. Brahma Pura1n2a
+
+<p><b>Brahma Pura1n2a</b> s. Anthologia sanscritica [pwj20]
+
+<p><b>Brahma S.</b> s. Brahmasu1tra
+
+<p><b>Brahmasu1tra</b>
+<p>--...Von Ba1dara1yana. 1. s. S4am2kara 2. Ed. K. M. Banerjea, Calcutta, 1870.
+[I.O. 519] pw
+
+<p><b>Brahma Upanis2ad</b> s. Atharvan2a Upanis2ads
+
+<p><b>Brahmav.</b> s. Brahmavaivarta Pura1n2a
+
+<p><b>Brahmavaivarta Pura1n2a</b>
+<p>--...Ohne weiteres im PW und pw.
+
+<p><b>Brahmop.</b> s. Brahma Upanis2ad
+
+<p><b>Br2hada1ran2yaka Upanis2ad</b>
+<p>--...Ed. E. Röer, Calcutta, 1849-56. [I.O. 541] PW, pw
+<p>--...Ed. L. Poley, Bonn, 1844. [Gild. 78] PW
+
+<p><b>Br2hadd.</b> s. Br2haddevata
+
+<p><b>Br2haddevata</b>
+<p>--...Ein Verzeichnis von Gottheiten im R2gveda von Saunaka. PW, pw In: R. Roth:
+Zur L. u. G. d. W. Seite 49. Stuttgart, 1846.
+
+<p><b>Br2haddharma P.</b> s. Br2haddharma Pura1n2a
+
+<p><b>Br2haddharma Pura1n2a</b>
+<p>--...Nach Anführungen im S4KD. PW
+
+<p><b>Br2hajja1taka</b>
+<p>--...Ein Werk über Astrologie von Vara1hamihira. PW
+
+<p><b>Br2hanm.</b> s. Br2hanmanu
+
+<p><b>Br2hanmanu</b>
+<p>--...Nach Zitaten in verschiedenen juristischen Büchern. pw
+
+<p><b>Br2h.A1r.Up.</b> s. Br2hada1ran2yaka Upanis2ad
+
+<p><b>Br2hasp.</b> s. Br2haspati
+
+<p><b>Br2haspati</b>
+<p>--...Verfasser eines Gesetzbuches nach Anführungen im Mita1ks2ara und
+D9yabha1ga. PW,pw s. Dharmas4a1stra
+
+<p><b>Br2hatsam2hita1</b>
+<p>--...Ein Werk über Astrologie von Vara1hamihira. PW
+
+<p><b>Br2h.Dev.</b> s. Br2haddevata
+
+<p><b>Buddhokt.</b> s. Buddhoktasam2sa1ra1maya
+
+<p><b>Buddhoktasam2sa1ra1maya</b>
+<p>--...Handschrift in der Pariser Bibliothek. Nach Schiefner. PW
+
+<p><b>Bühler, G.</b> Detailed Report of a Tour in Search of Sanscrit Manuscripts
+made in Kas4mi1r, Ra1jputa1na and Central India, Bombay, 1877. pw [pwj21]
+
+<p><b>Bühler, Guj.</b> A Catalogue of Sanscrit Manuscripts from Gujerat, Bombay,
+1871-73. pw
+
+<p><b>Bühler, Rep.</b> s. Bühler. G.
+
+<p><b>Bull. hist. phil.</b> = Bulletin historicophilologique de l'Acade4mie
+Impe4riale des Sciences de St. Petersbourg. PW
+
+<p><b>Burnell, T.</b> Classified Index of the Sanscrit Manuscripts in the Palace
+of Tanjore. pw
+
+<p><b>Burn. Intr.</b> s. Introduction
+
+<p><b>Burn. Lot. de la b.L.</b> s. Le Lotus
+
+<p><b>Bydragen</b> Tot de Taal--, Land--, en Volkenkunde van Nederlandsch Indie.
+pw
+
+<p><b>c11</b> = s4es4a
+
+<p><b>C11abdak4.</b> s. S4abdacandrika1
+
+<p><b>C11abdam.</b> s. Sabdama1la1
+
+<p><b>C11abdar.</b> s. Sabdaratna1vali1
+
+<p><b>C11abda1rn2.</b> s. Sabda1rn2ava
+
+<p><b>Caitanyacandrodaya</b>
+<p>--...Ed. R. Mitra, Calcutta, 1854. [I.O. 574] pw
+
+<p><b>C11a1k.</b> s. S4a1kuntala
+
+<p><b>Cakradatta</b>
+<p>--...Ein Kommentator von Caraka und Sus4ruta. Handschrift. pw
+
+<p><b>C11am2k.</b> s. S4am2kara
+
+<p><b>C11am2kar.</b> s. S4am2kara
+
+<p><b>C11am2k. Vig4.</b> s. S4am2karavijaya
+
+<p><b>Campaka</b>
+<p>--...Ed. A. Weber, Berlin, 1883. pw In: Sitzungsberichte der königlich
+preussischen Akademie der Wissenschaften zu Berlin, 1883. Seite 567 ff., 885
+ff.
+
+<p><b>Ca1nakhya</b> s. Ka1vyasam2graha
+
+<p><b>C11a1n2d2.</b> s. S4a1n2d2ilya
+
+<p><b>Candra1loka</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>C11a1n4kh.Br.</b> s. S4a1n3kha1yana Bra1hman2a
+
+<p><b>C11a1n3kh. C11r.</b> s. S4a1n3kha1yana S4rautasu1tra
+
+<p><b>C11a1n3kha. Gr2hjj.</b> s. S4a1n3kha1yana Gr2hyasu1tra
+
+<p><b>C11a1nt.</b> s. S4a1ntanava
+
+<p><b>C11a1ntic11.</b> s. S4a1ntis4ataka [pwj22]
+
+<p><b>Cantor</b> s. Geschichte der Mathemathik
+
+<p><b>Carakasm2hita1</b>
+<p>--...Ed. J. Vidya1sa1gara, Calcutta, 1877. [I.O. 611] pw
+
+<p><b>C11a1ri3g. Paddh.</b> s. S4a1rn3gadhara Paddhati
+
+<p><b>C11a1rn3g. Sam2.</b> s. S4a9rn3gadhara Sam2hita1
+
+<p><b>Ca1taka</b>
+<p>--...Gedicht vom Vogel Ca1taka in der Zeitschrift für die Kunde des
+Morgenlandes, IV, Seite 374-376. PW
+
+<p><b>Cat. All.</b> s. Cudh
+
+<p><b>C11atar. Up.</b> s. S4atarudri1ya Upanis2ad
+
+<p><b>C11at. Br.</b> s. S4atapatha Bra1hman2a
+
+<p><b>Cat. C. Pr.</b> s. Kielhorn
+
+<p><b>Cat. Gujar.</b> s. Bühler, Guj.
+
+<p><b>Cat. Kielh.</b> s. Kielhorn
+
+<p><b>Cat. NW. Pr.</b> s. North Western Provinces
+
+<p><b>C11atr.</b> s. S4atrum2jayamaha1tmya
+
+<p><b>Caturadha1yika1</b>
+<p>--...Von S4aunaka. Ohne weiteres im PW.
+
+<p><b>Caturbhuja</b>
+<p>--...Ein Scholiast des Maha1bha1rata. PW
+
+<p><b>Caturvargacinta1man2i1</b>
+<p>--...Von Hemadri. Ed. Bh. S4iroman2i, Calcutta, 1873-79. [I.O. 630] pw
+
+<p><b>Cat. willmot</b> s. Willmot
+
+<p><b>C11aun. K4at.</b> s. Caturadhya1yika1
+
+<p><b>Caurapan5ca1s4ika1</b>
+<p>--...1. s. Bhartr2hari
+<p>--...2. Ed. M. Ariel, Journal asiatique, 4me Se4rie, Bd. 11, S. 469, pw
+
+<p><b>Cha1ndogyaparis4is2t2a</b>
+<p>--...Nach Zitaten in anderen Werken. pw
+
+<p><b>Cha1ndogya Upanis2ad</b> s. Taittiri1ya Upanis2ad
+
+<p><b>Chandoman5jari1</b>
+<p>--...Ed. Brockhaus. In: Berichte über die Verhandlungen der königlich
+sächsischen Gesellschaft der wissenschaften zu Leipzig, Phil. hist. Kl., Bd.
+VI, 1854. PW, pw
+
+<p><b>Childers R.C.</b> Dictionary of the Pali Language, London, 1875. pw
+
+<p><b>Chr.</b> s. Sanskrit Chresthomathie
+
+<p><b>C11ic11.</b> s. S4is4upa1lavadha
+
+<p><b>C11iv.</b> s. S4ivana1masahasra [pwj23]
+
+<p><b>C11KDr.</b> = S4abdakalpadruma
+
+<p><b>c11l.</b> = Sloka
+
+<p><b>C11obh.</b> s. S4obhanastuti
+
+<p><b>Colebr.</b> s. Algebra und Miscellaneous Essays
+
+<p><b>Commentary</b> Commentary of the Hindu System of Medicine. By Th. A. Wise,
+Calcutta, 1845. PW
+
+<p><b>Commentatio</b> Commentatio geographica von Chr. lassen, Bonn, 1827. PW
+
+<p><b>Corapan5ca1s4at</b> s. Caurapan5ca1s4ika1
+
+<p><b>Cr11a1ddhaviv.</b> s. S4ra1ddhaviveka
+
+<p><b>C11ri1dhar.</b> s. S4ri1dharasva1min
+
+<p><b>C11r1i1p.</b> s. S4ri1patti
+
+<p><b>C11r2n4ga1rat.</b> s. S4r2n4ga1ratilaka
+
+<p><b>C11rut.</b> s. S4rutabodha
+
+<p><b>C11uk. oder C11ukas.</b> s. S4ukasaptati
+
+<p><b>C11ukran.</b> s. S4ukrani1ti
+
+<p><b>C11ulbas.</b> s. S4ulvasu1tra
+
+<p><b>Cu1lika Upanis2ad</b> s. Atharvan2a Upanis2ads
+
+<p><b>Cunningham Arch Survey</b> s. Archeological Survey
+
+<p><b>C11veta1c11v. Up.</b> s. S4veta1s4vatara Upanis2ad
+
+<p><b>Dac11.</b> s. Da1s4arathas Tod
+
+<p><b>Dac11abh.</b> s. Das4abhumi1s4vara
+
+<p><b>Dac11ack.</b> s. Das4akuma1racarita
+
+<p><b>Daivatabra1hman2a</b>
+<p>--...1. Ed. S. S4a1masva1mi, Calcutta, 1875. 1876. [I.O. 674] pw
+<p>--...2. Ed.  s. Daivatabra1hman2a
+
+<p><b>Daiv Br.</b> s. Daivatabra1hman2a
+
+<p><b>Da1j. oder Da1jabh.</b> s. Da1yabha1ga
+
+<p><b>Damayanti1katha1</b>
+<p>--...Handschrift. pw
+
+<p><b>Darpadalana</b>
+<p>--...Von Ks2emendra. Handschrift. pw
+
+<p><b>Das4abhu1mi1s4vara</b>
+<p>--...Handschrift in der Pariser Bibliothek. Nach A. Schiefner. PW
+
+<p><b>Das4akuma1racarita</b>
+<p>--...1. Ed. H. H. Wilson, Berlin, 1846. [Gild. 236] PW
+<p>--... 2. Ed. M. R. Kale, Bombay, 1925. (?) [I.O. 692] pw
+<p>--...3. Ed. G. Bühler, Bombay, 1887. 1891. [I.O. 691] pw [pwj24]
+
+<p><b>Das4arathas Tod</b> s. Sanskrit Chresthomathie
+
+<p><b>Das4aru1pa</b>
+<p>--...Ed. F. E. hall, Calcutta, 1865. [I.O. 698] pw
+
+<p><b>Dattaka Mi1ma1m2sa1</b>
+<p>--...Ed. J. C. C. Sutherland, Calcutta, 1817. [Gild. 349] PW Mit
+Dattakachandrika1
+
+<p><b>Datt. Mi1m.</b> s. Dattaka Mi1ma1m2sa1
+
+<p><b>Dattakas4iroman2i1</b>
+<p>--...Ed. Bh. S4iroman2i1, Calcutta, 1867. [I.O. 707] pw
+
+<p><b>Da1yabha1ga</b>
+<p>--...Ed. K. Tarka1lam2ka1ra, Calcutta, 1829. [I.O. 714] PW, pw
+
+<p><b>Dec11in.</b> s. Des4i1na1mama1la1
+
+<p><b>Des4i1na1mama1la1</b>
+<p>--...Ein Lexikon über Des4iformen im Prakrit von Hemacandra. Handschrift. pw
+
+<p><b>Dev.</b> s. Devi1ma1ha1tmya
+
+<p><b>Devala</b>
+<p>--...Nach Zitaten in verschiedenen juristischen Büchern. pw
+
+<p><b>Devata1dhj. Bra1hm.</b> s. Daivatabra1hman2a
+
+<p><b>Devi1bh1gavata1 Pua1n2a</b>
+<p>--...Handschrift. pw
+
+<p><b>Devi1ma1ha1tmya</b>
+<p>--...Ed. L. Poley, Berlin, 1831. [Gild. 130] PW
+
+<p><b>Devi1 P.</b> s. Devi1 Pura1n2a
+
+<p><b>Devi1 Pura1n2a</b>
+<p>--...Nach Anführungen im S4KD. pw
+
+<p><b>Dhammp.</b> s. Dhammapada
+
+<p><b>Dhammapada</b>
+<p>--...Ed. V. Fausböll, Kopenhagen, 1855. pw
+
+<p><b>Dhanam2jayavijaya</b>
+<p>--...Ed. T. Tarkava1caspati, Calcutta, 1871. [I.O. 752] pw
+
+<p><b>Dhanv.</b> s. Dhanvantaris Wörterbuch
+
+<p><b>Dhanvantaris Wörterbuch</b>
+<p>--...Handschrift, pw
+
+<p><b>Dhar.</b> s. Dharan2i1kos4a
+
+<p><b>Dharan2i1kos4a</b>
+<p>--...Ein Wörterbuch, angeführt im S4KD. PW [pwj25]
+
+<p><b>Dharmas4a1stra</b>
+<p>--...Die Darstellung der Lehre von den Schriften in Br2haspatis Dharmas4a1stra.
+Inauguraldissertation von A. A. Führer. pw
+
+<p><b>Dha1tup.</b> s. Dha1tupa1tha
+
+<p><b>Dha1tupa1tha</b> s. Radices
+
+<p><b>Dhu1rtan.</b> s. Dhu1rtanartaka
+
+<p><b>Dhu1rtanartaka</b>
+<p>--...Handschrift. pw
+
+<p><b>Dhu1rtas.</b> s. Dhu1rtasama1gama
+
+<p><b>Dhu1rtasama1gama</b> s. Anthologia sanscritica
+
+<p><b>Dh. V.</b> s. Dhanam2jayavijaya
+
+<p><b>Dhya1navindu1panis2ad</b> s. Atharvan2a Upanis2ads
+
+<p><b>Divja1v.</b> s. Divya1vada1na
+
+<p><b>Divya1vada1na</b>
+<p>--...Handschrift. PW, pw
+
+<p><b>Donner, Pin2d2.</b> s. Pin2d2apitr2yajn5a
+
+<p><b>Dra1hya1yana</b>
+<p>--...Verfasser eines S4rautasu1tras. PW
+
+<p><b>Draup.</b> s. Draupadi1prama1tha
+
+<p><b>Draupadi1prama1tha</b> s. Arjunasama1gama
+
+<p><b>Dravyas4uddhitattva</b>
+<p>--...Handschrift. pw
+
+<p><b>Durgad.</b> s. Durgada1sa
+
+<p><b>Durgada1sa</b>
+<p>--...Ohne weiteres im PW.
+
+<p><b>Durga1rcatattva</b>
+<p>--...Nach Anführungen im S4KD. PW
+
+<p><b>Durga1rk4at.</b> s. Durga1rcatattva
+
+<p><b>Dviru1pak.</b> s. Dviru1pakos4a
+
+<p><b>Dviru1pakos4a</b>
+<p>--...Eine Wortsammlung, nach Anführungen im S4KD. PW
+
+<p><b>Dvived.</b> s. Dvivedagan3ga
+
+<p><b>Dvivedagan3ga</b>
+<p>--...Ein Scholiast des Ma1dhyam2dina A1ran2yaka. PW
+
+<p><b>Eitel, Chin. B.</b>
+<p>--...Handbook forthe Student of Chinese Buddhism. Von E. J. Eitel, London,
+1870. pw
+
+<p><b>Flora indica</b>
+<p>--..., or the Description of Indian Plants. Von W. Roxburg, Serampore, 1932.
+PW, pw [pwj26]
+
+<p><b>Führer, Br2h.</b> s. Dharmas4a1stra
+
+<p><b>G4a1b. Up.</b> s. Ja1ba1la Upanis2ad
+
+<p><b>G4aim.</b> s. Jaimini
+
+<p><b>Gal.</b> s. Galanos
+
+<p><b>Galanos</b> Galanos Wörterbuch. Abschrift von A. Weber. Monatsbericht der
+königlich preussischen Akademie der Wissenschften, Berlin, 1876. Seite 801 ff.
+pw
+
+<p><b>ganapa1tha</b> s. Pa1n2ini
+
+<p><b>Ganar.</b> s. Ganaratnamahodadhi
+
+<p><b>Ganaratnamahodadhi</b>
+<p>--...1. s. Pa1n2ini || 2. Ed. J. Eggeling, London, 1879. [I.O. 851] pw
+
+<p><b>Gan2ita</b> Mit: Graha1nayana1dhya1ya, Bhagana1dhya1ya,
+Tripras4na1dhika1ra, Pratyabdhas4uddhi, Bhagrahayutyadhika1ra, Kaks2a1dhya1ya,
+Spas2t2a1dhika1ra, Candragraha1dhika1ra, Adhima1sanirn2aya,
+Grahaccha1ya1dhika1ra, Madhyama1dhya1ya, Su1ryagrahan2a1dhika1ra. pw
+
+<p><b>Garbha Upanis2ad</b> s. Atharvan2a upanis2ads
+
+<p><b>Garbhop.</b> s. Garbha Upanis2ad
+
+<p><b>Ga1ruda Upanis2ad</b> s. Atharvan2a Upanis2ads
+
+<p><b>Ga1r. Up.</b> s. Ga1ruda Upanis2ad
+
+<p><b>G4ata1dh.</b> s. Jata1dhara
+
+<p><b>Gaudap.</b> s. Gaudapa1da
+
+<p><b>Gaudapa1da</b>
+<p>--...1. Ein Scholiast zur Sa1m2khya Ka1rika1. PW, pw
+<p>--...2. Ein Scholiast zur Ma1n2d2u1kya Upanis2ad. PW
+
+<p><b>Gaut.</b> s. Gautamadharmas4a1stra
+
+<p><b>Gautamadharmas4a1stra</b>
+<p>--...Ed. A. F. Stenzler, London, 1876. [I.O. 893] pw
+
+<p><b>Gel. Anzz. d.k.b.Ak.d.Ww.</b> = Gelehrte Anzeigen der königlich
+bayerischen Akademie der Wissenschaften, München. PW
+
+<p><b>Geschichte der Mathemathik</b>
+<p>--...Von M. B. Cantor, Heidelberg, 1880-1908. pw
+
+<p><b>Geschichte des Buddhismus</b>
+<p>--...Von Ta1rana1tha. Aus dem Tibetischen übersetzt von A. Schiefner. pw
+
+<p><b>Geschichte des Vidu1s2aka</b> s. Sanskrit Chresthomathie
+
+<p><b>Ghat2.</b> s. Ghat2akarpara [pwj27]
+
+<p><b>Ghat2akarpara</b> s. Amarus4ataka
+
+<p><b>Gild. Bibl.</b> s. Bibliotheca sanscrita
+
+<p><b>Gild. Scriptorum Arabum</b> s. Scriptorum Arabum
+
+<p><b>Gi1t.</b> s. Gi1tagovinda
+
+<p><b>Gi1tagovinda</b>
+<p>--...Ed. Chr. Lassen, Bonn, 1836. [I.O. 912] PW, pw
+
+<p><b>G4jot.</b> s. Jyotis2am
+
+<p><b>G4jotishat.</b> s. Jyotis2atattva
+
+<p><b>Gobh.</b> s. Gobhile Gr2hyasu1tra
+
+<p><b>Gobh. C11ra1ddhak.</b> s. Gobhilagr2hyasu1tra
+
+<p><b>Gohilagr2hyasu1tra</b>
+<p>--...1. Nach Mitteilungen von A. Weber. PW
+<p>--...2. Ed. Tarka1lam2ka1ra, Calcutta, 1871-80. [I.O. 924] pw Mit
+S4ra1ddhakalpasutra
+
+<p><b>Gola1dhj.</b> s. Gola1dhya1ya
+
+<p><b>Gola1dhya1ya</b> s. Siddha1ntas4iroman2i
+
+<p><b>Gold.</b> s. Goldstückers Wörterbuch
+
+<p><b>Goldstückers Wörterbuch</b> im pw
+
+<p><b>Gopathabra1hman2a</b>
+<p>--...Ed. R. Mitra, H. Vidya1bhu1s2an2a, Calcutta, 1872. [I.O. 943] pw
+
+<p><b>Gop. Br.</b> s. Gopathabra1hman2a
+
+<p><b>Gorr.</b> s. Gorresio
+
+<p><b>Gorresio</b> s. Ra1ma1yan2a
+
+<p><b>Gotama</b> s. Nya1ya
+
+<p><b>Got. S.</b> s. Nya1yasu1tra
+
+<p><b>Govardh.</b> s. Govardhana
+
+<p><b>Govardhana</b> s. Saptas4ati
+
+<p><b>Govindabh.</b> s. Govindabhat2t2a
+
+<p><b>Govindabhat2t2a</b>
+<p>--...Ohne weiteres im PW.
+
+<p><b>Govinda1n.</b> s. Govinda1nanda
+
+<p><b>Govinda1nanda</b>
+<p>--...Glossator zu S4am2karas Kommentar zu Ba1dara1yan2a. pw
+
+<p><b>Gr2hjas.</b> s. Gr2hysam2graha
+
+<p><b>Gr2hjasam2gr.</b> s. Gr2hyasam2grahaparis4is2t2a
+
+<p><b>Gr2hyasam2graha</b> = Gobhila Gr2hyasu1tra
+
+<p><b>Gr2hyasam2grahaparis4is2t2a</b>
+<p>--...Zum Gobhila Gr2hyasu1tra. Handschrift. PW [pwj28]
+
+<p><b>H.</b> = Hemacandra
+
+<p><b>Haeb. Anth.</b> s. Haeberlins Chresthomathie (Anthologie)
+
+<p><b>Heab. Chrest.</b> s. Haeberlins Chresthomathie
+
+<p><b>Haeberlins Chresthomathie</b> s. Ka1vyasam2graha
+
+<p><b>Ha1la</b> s. Saptas4ataka
+
+<p><b>Ha1laj.</b> s. Ha1la1yuddha
+
+<p><b>Ha1la1yuddha</b>
+<p>--...Ein Lexikograph 1. Nach Anführungen im S4KD. PW 2. Ha1la1yuddhas
+Abhidha1naratnama1la1. Ed. Th. Aufrecht, Lahore, 1928. (?) [I.O. 6] pw
+
+<p><b>Ham2sa Upanis2ad</b> s. Atharvan2a Upanis2ads
+
+<p><b>Ham2sop.</b> s. Ham2sa Upanis2ad
+
+<p><b>H.an.</b> s. Aneka1rthasam2graha
+
+<p><b>Handbuch der Sanskritsprache</b>
+<p>--...Von Theodor Benfey, Leipzig, 1853, 1954. PW 1. Vollständige Grammatik 2.
+Chresthomathie
+
+<p><b>Hanumaduktara1mopanis2ad</b> s. Atharvan2a Upanis2ads
+
+<p><b>Hanum. Up.</b> s. Hanumaduktara1mopanis2ad
+
+<p><b>Ha1r.</b> s. Ha1ra1vali1
+
+<p><b>Ha1ra1vali1</b> Amarakos4a, Ha1ra1vali1, Medini1kos4a, Cura Colebrookii,
+Calcutta, 1807. [Gild. 258] PW, pw Am Ende des Medini1kos4a steht das Werk
+Avyaya1neka1rthavarga.
+
+<p><b>Harisv.</b> s. Harisva1min
+
+<p><b>Harisva1min</b>
+<p>--...Ein Scholiast des S4atapathabra1hman2a. PW, pw
+
+<p><b>Hariv.</b> s. Harisvam2s4a
+
+<p><b>Harivam2s4a</b>
+<p>--...1. Ed. M. A. Langlois, London, 1834. 1835. [Gild. 122] PW, pw 2. und 3.
+Eine ältere Calcuttaer Ausgabe und eine neurere lithographierte Ausgabe. pw
+
+<p><b>Hariv. Langl.</b> s. harivam2s4a
+
+<p><b>Hars2acarita</b>
+<p>--...Von Ba1na. Ed. J. Vidya1sa1gara, Calcutta, 1876. [I.O. 1042] pw
+
+<p><b>Harshak4.</b> s. Hars2acarita
+
+<p><b>Ha1sj.</b> s. Ha1sya1rn2ava
+
+<p><b>Ha1sya1rn2ava</b>
+<p>--...1. Handschrift. pw
+<p>--...2. Ed. C. Cappeller, Jena, 1883. [I.O. 1049] pw [pwj29]
+
+<p><b>Haug.</b>
+<p>--...Uber das Wesen und den Wert des vedischen Akzentes, München, 1874. pw
+
+<p><b>Haughton</b> A Dictionary Benga1li and Sanskrit. Von G. C. Haughton,
+London, 1833. PW
+
+<p><b>H. c11.</b> = S4es4as in Hemacandras Abhidha1nacinta1man2i1, Seite
+421-443. PW, pw
+
+<p><b>Hemacandra</b> s. Abhidha1nacinta1man2i1 und Aneka1rthasam2graha
+
+<p><b>Hemacandras Prakrit Grammtik</b>
+<p>--...1. Ed. Bombay, 1872. [I.O. 1938] pw
+<p>--...2. Ed. R. Pischel. Halle, 1877, 1880. [I.O. 1938] pw
+
+<p><b>Hemacandras Yogas4a1stra</b> s. Yogas4a1stra
+
+<p><b>Hema1dri</b> s. Caturvargacinta1man2i1
+
+<p><b>Hem. Jog.</b> s. Yogas4a1stra
+
+<p><b>Hem. Par.</b> s. Paris4is2t2aparvan
+
+<p><b>Hem. Pr. Gr.</b> s. Hemacandras Prakrit Grammatik
+
+<p><b>Hessler</b> s. Sus4ruta
+
+<p><b>Hid.</b> s. Hidimbavadha
+
+<p><b>Hidimbavadha</b> s. Indraloka1gamana
+
+<p><b>Hillebrandt</b> Das altindische Neu- und Vollmondsopfer, Jena, 1879. pw
+
+<p><b>Hindu Th. (Wilson)</b> s. Wilson
+
+<p><b>Hiouen Thsang</b>
+<p>--...1. Histoire de la vie de Hiouen Thsang et de ses voyages
+dans l'Inde. Traduite du Chinois per Stanislas Julien, Paris, 18533. PW
+<p>--...2. Me4moires sur les contre4es occidentales, traduites du Sanscrit en Chinois en
+l'an 648 par Hiouen Thsang, et du Chinois en Franc11ais par M. Stanislas Julien.
+PW
+
+<p><b>Hit.</b> = Hitopades4a
+
+<p><b>Hit. ed. Johns.</b> s. Hitopades4a
+
+<p><b>Hitopades4a</b>
+<p>--...1. Ed. Schlegel und Lassen, Bonn, 1829. [Gild. 225] PW, pw
+<p>--...2. Ed. F. Johnson, London, 1847-48. [I.O. 1070] pw
+
+<p><b>Hit. Pr.</b> = Prooemium zum Hitopades4a
+
+<p><b>Hora1c11.</b> s. Hora1s4a1stra
+
+<p><b>Hora1s4a1stra</b>
+<p>--...Ohne weiteres im PW.
+
+<p><b>Hort. beng.</b> s. Hortus bengalensis
+
+<p><b>Hort. calc.</b> s. Hortus suburbanus calcuttensis
+
+<p><b>Hortus bengalensis</b>
+<p>--...Zitiert nach haughtons Wörterbuch. PW [pwj30]
+
+<p><b>Hortus subrubanus calcuttensis</b>
+<p>--...A Catalogue of Plants. Von J. O. Voigt, Calcutta, 1845. PW
+
+<p><b>I1c11op.</b> s. I1s4a Upanis2ad
+
+<p><b>Ind. Antiq.</b> s. Indian Antiquary
+
+<p><b>Ind. d. Kand4.</b> s. Index des Kanjur
+
+<p><b>Index des Kanjur</b>
+<p>--...Ed. I. J. Schmidt, St. Petersburg, 1845. PW
+
+<p><b>India</b> India, what can it teach us ? Von M. Müller. pw
+
+<p><b>Indische Altertumskunde</b>
+<p>--...Von Chr. Lassen, Bonn, 1844-62. PW. pw
+
+<p><b>Indisches Erbrecht</b>
+<p>--...Von A. Mayr, Wien, 1873. pw
+
+<p><b>Indische Sprüche</b>
+<p>--...Von O. Böhtlingk, St. Petersburg, 1863-65. [I.O. 1087] PW, pw
+
+<p><b>Indisches Schuldrecht</b>
+<p>--...Von J. Jolly, Münchner philos. --phil. Abhandlungen, 1877. S. 528ff pw
+
+<p><b>Indische Streifen</b>
+<p>--...Von A. Weber, Berlin, 1868. 1869. pw
+
+<p><b>Indische Studien</b>
+<p>--...Von A. Weber, Berlin, 1855-98. PW, pw Mit: Pra1tis4a1khya zur
+Va1jasaneyisam2hita1, Supara1dhya1ya, Ed. E. Grube, Prasta1nabeda von
+Madhusu1danasarasvati, Pratijn5a1su1tra, Yogara1tra von Vara1hamihira,
+Yogatattva.
+
+<p><b>Indr.</b> s. Indraloka1gamana
+
+<p><b>Indraloka1gamana</b> Ardschunas Reise zu Indras Himmel [Indraloka1gamana,
+Bra1hman2avila1pa, Hidimbavadha, Sundopasundopa1khya1na,] Ed. F. Bopp, Berlin,
+1824. [I.O. 1500] PW
+
+<p><b>Ind. St.</b> s. Indische Studien
+
+<p><b>Ind. Str.</b> s. Indische Streifen
+
+<p><b>Institutiones Linguae Pracriticae</b>
+<p>--...Von Chr. Lassen, Bonn, 1837. PW
+
+<p><b>Institt. (Lassen)</b> s. Institutiones Linguae Pracriticae
+
+<p><b>Introduction a l'histoire indienne</b>
+<p>--...Von M. E. Burnouf, Paris, 1844. PW, pw
+
+<p><b>I1s4a Upanis2ad</b> s. Taittiri1ya Upanis2ad
+
+<p><b>Itih.</b> = Itiha1sa
+
+<p><b>Ja1ba1la Upanis2ad</b> s. Atharvan2a Upanis2ads
+
+<p><b>Ja1g4n4.</b> s. Ya1jn5avalkya [pwj31]
+
+<p><b>Ja1g4n4ad. (Lois. )</b> s. Ya1jn5adattavadha
+
+<p><b>Ja1g4n4ikad. Paddh. zu Ka1tj. C11r.</b> s. Ya1jn5ikadevas Paddhati
+
+<p><b>Jag4. V.</b> s. Yajurveda
+
+<p><b>Jaimini</b> s. Mi1ma1m2sa1
+
+<p><b>Jaimini1yanya1yama1la1vista1ra</b>
+<p>--...Ed. Th. Goldstücker, E. B. Cowell, London, 1878. [I.O. 1621] pw
+
+<p><b>J. A. O. S.</b> = Journal of the American Orientel Society. pw
+
+<p><b>J. A. S. Beng.</b> = Journal of the Asiatic Society of Bengal. pw
+
+<p><b>Jata1dhara</b>
+<p>--...Ein Lexikograph, angeführt im S4KD. PW, pw
+
+<p><b>Ja1takama1la1</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>Javanec11.</b> s. Yavanes4vara
+
+<p><b>Jogac11. Up.</b> s. Yogas4ikha Upanis2ad
+
+<p><b>Jogas.</b> s. Yogasu1tra
+
+<p><b>Jogat. Up.</b> s. Yogatattva Upanis2ad
+
+<p><b>Jolly</b> s. Indisches Schuldrecht
+
+<p><b>Journ. as.</b> = Journal Asiatique
+
+<p><b>Journ. of the Am. Or. S.</b> = Journal of the American Oriental Society.
+PW
+
+<p><b>J.R.A.A.</b> = Journal of the Royal Asiatic Society
+
+<p><b>Jyotis2am</b>
+<p>--...Uber den Vedakalender namens Jyotis2am. Von A. Weber, Berlin, 1862. pw
+
+<p><b>Jyotis2a zum Atharvaveda</b>
+<p>--...Handschrift. pw
+
+<p><b>Jyotis2atattva</b>
+<p>--...Nach Anführungen im S4KD. PW
+
+<p><b>Ka1c11.</b> s. Ka1s4ika1 Vr2tti
+
+<p><b>Ka1d. oder Ka1damb.</b> s. Ka1dambari
+
+<p><b>Ka1dambari1</b>
+<p>--...1. Handschrift. PW
+<p>--...2. Ed. Calcutta, 1852. [I.O. 1203] pw
+
+<p>--...3. Ed. Calcutta, 1871. [I.O. 1205] pw
+
+<p><b>Kaij.</b> s. Kaiyata
+
+<p><b>K4aitanj.</b> s. Caitanyacandrodaya
+
+<p><b>Kaivaljob.</b> s. Kaivalya Upanis2ad
+
+<p><b>Kaivalya Upanis2ad</b> s. Atharvan2a Upanis2ads
+
+<p><b>Kaiv. Up.</b> s. Kaivalya Upanis2ad [pwj32]
+
+<p><b>Kaiyata</b>
+<p>--...Ein Kommentator zum Maha1bha1s2ya. PW
+
+<p><b>K4akr.</b> s. Cakradatta
+
+<p><b>Ka1lacakra</b>
+<p>--...Handschrift. pw
+
+<p><b>Ka1lak4.</b> s. Ka1lacakra
+
+<p><b>Ka1lanirn2aya</b>
+<p>--...Von Ma1dhava. Ohne weiteres im pw.
+
+<p><b>Ka1lasam2kalita1</b>
+<p>--...Zitiert nach Haughtons Wörterbuch. PW
+
+<p><b>Ka1lid.</b> = Ka1lida1sa
+
+<p><b>Ka1lika P.</b> s. Ka1lika Pura1n2a
+
+<p><b>Ka1lika1 Pura1n2a</b>
+<p>--...Nach Anführungen im S4KD. PW
+
+<p><b>Kalpadruma1v.</b> s. Kalpadruma1vada1na
+
+<p><b>Kalpadruma1vada1na</b>
+<p>--...Handschrift in der Pariser Bibliothek. Nach Schiefner. PW
+
+<p><b>Kalpas.</b> s. Kalpasu1tra
+
+<p><b>Kalpasu1tra</b>
+<p>--...Von Bhadraba1hu. Ed. H. Jacobi, Leipzig, 1879. [I.O. 1231] pw
+
+<p><b>Ka1mandaki1yani1tisa1ra</b>
+<p>--...Ed. R. Mitra, Calcutta, 1861. [I.O. 1861] pw
+
+<p><b>Ka1m. Ni1tis.</b> s. Ka1mandaki1yani1tisa1ra
+
+<p><b>K4a1n2:</b> s. Ca1n2akhya
+
+<p><b>Kan2.</b> s. Kan2a1da
+
+<p><b>Kan2a1da</b> s. Vais4es4ika
+
+<p><b>Ka1n2d2.</b> s. Ka1n2d2u1pa1khya1na
+
+<p><b>Kan2d2ak.</b> s. Kan2d2akaus4ika1
+
+<p><b>kan2d2akaus4ika1</b>
+<p>--...Von Ks2emi1s4vara. pw
+
+<p><b>Kandjur</b> s. Index des Kandjur
+
+<p><b>Ka1n2d2u1pa1khya1na</b> s. Anthologia sanscritica
+
+<p><b>Kan2t2haer. Up.</b> s. Kan2t2has4ruti Upanis2ad
+
+<p><b>Kan2t2ahas4ruti Upanis2ad</b> s. Atharvan2a Upanis2ads
+
+<p><b>Kap.</b> s. Kapila
+
+<p><b>Kap. (Ball. )</b> s. Kapila
+
+<p><b>Ka1pi1c11.</b> s. Ka1pi1s4a1vada1na
+
+<p><b>Kapila</b> s. Sa1m2khya [pwj33]
+
+<p><b>Ka1pi1s4a1vada1na</b>
+<p>--...Handschrift in der Pariser Bibliotherk. Nach Schiefner. PW
+
+<p><b>Kapis2t2halakatha1sam2hita1</b>
+<p>--...Handschrift. pw
+
+<p><b>Kap.</b> s. Kapis2t2halakatha1sam2hita1
+
+<p><b>Ka1r.</b> s. Ka1rika1
+
+<p><b>Ka1ran2d2.</b> s. Ka1ran2d2avyu1ha
+
+<p><b>Ka1ran2d2avyu1ha</b>
+<p>--...Ed. S. S4a1masva1mi, Calcutta, 1873. [I.O. 1972] pw
+
+<p><b>Ka1rika1</b>
+<p>--...Ohne weiteres im PW und pw.
+
+<p><b>Karmapr.</b> s. Karmpradi1pa
+
+<p><b>Karmapradi1pa</b>
+<p>--...Steht unter dem Falschen Titel Ka1tja1jana Smr2ti im
+Dharmas4a1strasam2graha, Vol. 1, Seite 603-644. PW, pw
+
+<p><b>Ka1s4ika1 Vr2tti</b>
+<p>--...In der Zeitschrift "The Pandit", 7 fgg und in Böhtlingks Einleitung zum
+Pa1n2ini. pw
+
+<p><b>Ka1s4ikhan2d2a</b>
+<p>--...Handschrift. pw
+
+<p><b>Ka1t.</b> s. Ka1tavema
+
+<p><b>Ka1t.</b> s. Ka1tantra
+
+<p><b>K4a1t.</b> s. Ca1taka
+
+<p><b>Ka1tantra</b>
+<p>--...Ed. J. Eggeling, Calcutta, 1874. [I.O. 1282] pw
+
+<p><b>Ka1tavema</b>
+<p>--...Ein Scholiast des S4a1kuntala. PW
+
+<p><b>Ka1thaka.</b>
+<p>--...Eine Rezension des weissen Yajurveda. Handschrift. PW. pw
+
+<p><b>Ka1thakagr2hyasu1tra</b>
+<p>--...Handschrift. pw
+
+<p><b>Ka1tha1rn2ava</b>
+<p>--...Handschrift. pw
+
+<p><b>Katha1s.</b> s. katha1saritsa1gara
+
+<p><b>Katha1saritsa1gara</b>
+<p>--...Ed. Brokhaus, Leipzig, 1839-43. [I.O. 1288] PW, pw
+
+<p><b>Kat2ha Upanis2ad</b> s. Taittiri1ya Upanis2ad
+
+<p><b>Ka1th.Gr2hj.</b> s. Ka1thaka Gr2hyasu1tra
+
+<p><b>Kathina1vada1na</b>
+<p>--...Handshrift nach Schiefner. PW [pwj34]
+
+<p><b>Kat2hop.</b> s. Kat2ha Upanis2ad
+
+<p><b>Ka1tj.</b> s. Ka1tya1yana
+
+<p><b>Ka1tj. C11ra1ddhak.</b> s. Ka1tya1yana S4ra1ddhakalpasu1tra
+
+<p><b>Ka1tj. Dh.</b> s. Ka1tya1yana Dharmasu1tra
+
+<p><b>Ka1tj. Paddh.</b> s. Ka1tya1yana S4rautasu1tra
+
+<p><b>K4aturbh.</b> s. Caturbhuja
+
+<p><b>Ka1tya1yana Dharmasu1tra</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>Ka1tya1yana Sna1nasu1tra</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>Ka1tya1yana S4ra1ddhakalpasu1tra</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>Ka1tya1yana S4rautasu1tra</b> s. Yajurveda
+
+<p><b>Kauc11.</b> s. Kaus4ikasu1tra
+
+<p><b>K4aurap.</b> s. Caurapan5ca1s4ikha1
+
+<p><b>Kaush. A1r.</b> s. Kaus4i1taki1 A1ran2yaka
+
+<p><b>Kaush. Br.</b> s. Kaus4i1taki1 Bra1hman2a
+
+<p><b>Kaush. Up.</b> s. Kaus4i1taki1 Bra1hman2a Upanis2ad
+
+<p><b>Kaus4ikasu1tra</b>
+<p>--...Zum Atharvaveda. Handschrift. PW, pw
+
+<p><b>Kaus4i1taki1 A1ran2yaka</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>Kaus4i1taki1 Bra1hman2a</b>
+<p>--...Ohne weiteres im PW.
+
+<p><b>Kaus4i1taki1 Bra1hman2a Upanis2ad</b> s. Atharvan2a Upanis2ads
+
+<p><b>Kautukar.</b> s. Kautukaratna1kara
+
+<p><b>Kautukaratna1kara</b>
+<p>--...Handschrift. pw
+
+<p><b>Kavikalpadr.</b> s. Kavikalpadruma
+
+<p><b>Kavikalpadruma</b>
+<p>--...Eine Wortsammlung, Angeführt im S4KD. PW
+
+<p><b>Kavikan2t2ha1bharan2a</b>
+<p>--...Von Ks2emendra. Ed. J. Schönberg, Wien, 1884. [I.O. 1308] pw
+
+<p><b>Ka1vjak4.</b> s. Ka1vyacandrika1
+
+<p><b>Ka1vjapr.</b> s. Ka1vyapraka1s4a
+
+<p><b>Ka1vyacandrika1</b>
+<p>--...Ein Lehrbuch der Rhetorik, nach Anführungen im S4KD. PW
+
+<p><b>Ka1vya1lm2ka1ra</b>
+<p>--...Von Va1mana. Mit Vr2tti. Ed. C. Cappeller, Jena, 1875. [I.O. 1316] pw
+[pwj35]
+
+<p><b>Ka1vyalokalocana</b>
+<p>--...Handschrift. pw
+
+<p><b>Ka1vyapraka1s4a</b>
+<p>--...Ed. Calcutta, 1829. [Gild. 265] PW, pw
+
+<p><b>Ka1vyasam2graha</b>
+<p>--...A Sanscrit Anthology. Von J. Haeberlin, Calcutta, 1847. PW, pw Mit:
+Ca1nakhya S4ataka, Sa1ntis4ataka von S4ihlana, A1nandalahari1, Navaratna,
+Ni1tipradi1pa.
+
+<p><b>Kena Upanis2ad</b> s. Taittiri1ya Upanis2ad
+
+<p><b>Kenop.</b> s. Kena Upanis2ad
+
+<p><b>Khan2d2apras4asti</b>
+<p>--...Im Pandit: Band 5 und 6. pw
+
+<p><b>K4han2d2om.</b> s. Chan2d2oman5jari1
+
+<p><b>K4ha1nd. Up.</b> s. Cha1ndogya Upanis2ad
+
+<p><b>Kielhorn</b> 1. A Catalogue of Sanscrit Manuscripts existing in the
+Central Provinces, Nagpur, 1874. pw 2. Report on the Search of Sanscrit
+Manuscripts in the Bombay Presidency, 1880-81. pw
+
+<p><b>Kir.</b> s. Kira1ta1rjuni1ya
+
+<p><b>Kira1ta1rjuni1ya</b>
+<p>--...Ed. Calcutta, 1814. [Gild. 139] PW, pw
+
+<p><b>Kopenhagen</b>
+<p>--...Verzeichnis der Kopenhagener Sanskrit Handschriften Von Westergaard. pw
+
+<p><b>Kos.</b> s. Kosegarten
+
+<p><b>Kosegarten</b> s. Pan5catantra
+
+<p><b>Kosht2ipr.</b> s. Kos2t2ipradi1pa
+
+<p><b>Kos2t2ipradi1pa</b>
+<p>--...Nach Anführungen im S4KD. PW
+
+<p><b>Kriya1sam2.</b> s. Kriya1sam2uccaya
+
+<p><b>Kriya1sam2uccaya</b>
+<p>--...Handschrift in der Pariser Bibliotherk. Nach Schiefner. PW
+
+<p><b>Kr2shis.</b> s. Kr2s2isam2graha
+
+<p><b>Kr2s2isam2graha</b>
+<p>--...Von Paras4ara. Ed. Calcutta, 1862. pw
+
+<p><b>Kr2s2n2ajanma1s2t2ami1</b>
+<p>--...Ed. A. Weber, pw. [pwj36]
+
+<p><b>Ks2emendra</b> s. Kavikan2t2ha1bharan2a
+
+<p><b>Ks2emi1s4vara</b> s. Kan2d2akaus4ika1
+
+<p><b>Kshiti1c11.</b> s. Ks2iti1s4avam2s4avali1carita
+
+<p><b>Kshur. Up.</b> s. Ks2urika Upanis2ad
+
+<p><b>Kshurikop.</b> s. Ks2urika Upanis2ad
+
+<p><b>Ks2iti1s4avam2s4avali1carita</b>
+<p>--...Ed. W. Pertsch, Berlin, 1852. [I.O. 1401] pw
+
+<p><b>Ks2urika Upanis2ad</b> s. Atharvan2a Upanis2ads
+
+<p><b>Kuhn's Z.</b> = Zeitschrift für vergleichende Sprachforschung auf dem
+Gebiete der indogermanischen Sprache. pw
+
+<p><b>Kula1rn2ava</b>
+<p>--...Handschrift. pw
+
+<p><b>K4u1likop.</b> s. Cu1lika Upanis2ad
+
+<p><b>Kull.</b> s. Kullu1ka
+
+<p><b>Kullu1ka</b> s. Manu
+
+<p><b>Kuma1ras.</b> s. Kuma1rasam2bhava
+
+<p><b>Kuma1rasam2bhava</b>
+<p>--...1. Ed. A. F. Stenzler, Berlin, 1838. [I.O. 1406] PW, pw
+<p>--...2. Ed. T. Tarkava1caspati, Calcutta, 1868. [I.O. 1408] pw
+
+<p><b>Kuma1rasv.</b> s. Kuma1rasva1min
+
+<p><b>Kuma1rasva1min</b>
+<p>--...Ein Kommentator des Prata1parudri1ya. pw
+
+<p><b>Kunt.</b> s. Kunta1pa
+
+<p><b>Kunta1pa</b>
+<p>--...10 Lieder, die einen besonderen Abschnitt von AV Buch 20 bilden. PW
+
+<p><b>Ku1rma P.</b> s. Ku1rma Pura1n2a
+
+<p><b>Ku1rma Pura1n2a</b>
+<p>--...Ohne weiteres im PW.
+
+<p><b>Kusum.</b> s. Kusuman5jali1
+
+<p><b>Kusuman5jali1</b>
+<p>--...Von Udayana. Ed. E. B. cowell, Calcutta, 1864. [I.O. 1807] pw
+
+<p><b>Kuvala1j.</b> s. Kuvala1ya1nanda
+
+<p><b>Kuvalaya1nanda</b>
+<p>--...1. Nach 2 lithographierten Ausgaben. pw
+<p>--...2. Von Appaya Di1ks2ita. Ed. Poona, 1846. [I.O. 1426] PW
+
+<p><b>LA.</b> s. Lassen
+
+<p><b>Laghug4.</b> s. Laghuja1taka
+
+<p><b>Laghuja1taka</b>
+<p>--...Von Vara1hamihira. PW, pw [pwj37]
+
+<p><b>Laghuk.</b> s. Laghukaumudi1
+
+<p><b>Laghukaumudi1</b>
+<p>--...1. Ed. Calcutta, 1811. [Gild. 245] PW
+<p>--...2. Ed. Ballantyne, Benares, 1867. [I.O. 1437] pw
+
+<p><b>Lalit.</b> s. Lalitavista1ra
+
+<p><b>Lalitavista1ra</b>
+<p>--...1. Ed. R. Mitra, Calcutta, 1853. 1877. [I.O. 1465] PW, pw
+<p>--...2. Rg Tcher Rol Pa ou De4velopment des Jeux. Ed. Ph. Ed. Foucaux, Paris,
+1848. PW
+
+<p><b>Lassen</b> s. Anthologia sanscritica, Indische Altertumskunde und
+Commentatio geographica
+
+<p><b>La1tj.</b> s. La1tya1yana S4rautasu1tra
+
+<p><b>La1tya1yana S4rautasu1tra</b>
+<p>--...1. Ed. A. Veda1ntava1gi1s4a, Calcutta, 1870-72. [I.O. 1468] pw
+<p>--...2. Handschrift. PW
+
+<p><b>Lebens.</b> s. Lebensbeschreibung
+
+<p><b>Lebensbeschreibung</b> Eine tibetische Lebensbeschreibung C11a1kjamunis,
+des Begründers des Buddhatums. Mitgeteilt von A. Schiefner. In: Me4moires
+pre4sente4es a l'Acade4mie Impe4riale des Sciences de St. Pe4tersbourg par
+divers savants. T. VI. PW
+
+<p><b>Le Lotus</b> Le Lotus de la bonne Lois. Aus dem Sanskrit ins Französische
+von M. E. Burnouf, Paris, 1852, pw
+
+<p><b>Leumann</b> s. Aupapa1tikasu1tra
+
+<p><b>Lex. sanscr. tib.</b> s. Vyutpatti
+
+<p><b>Lia.</b> s. Indische Altertumskunde
+
+<p><b>Li1lia1vati1</b>
+<p>--...Von Bha1skara A1cha1rya. (Bhi1jagan2ita) Ed. Calcutta, 1846. [I.O. 2466]
+PW, pw
+
+<p><b>Lin3ga P.</b> s. Lin3ga Pura1n2a
+
+<p><b>Lin3ga Pura1n2a</b>
+<p>--...Ohne weiteres im PW.
+
+<p><b>List of Sanscrit Manuscripts</b> s. Oppert
+
+<p><b>Lit. (Web. )</b> s. Akademische Vorlesungen
+
+<p><b>L.K.</b> s. Laghukaumudi1
+
+<p><b>Lois.</b> s. Loiseleur
+
+<p><b>Loiseleur</b> s. Manu
+
+<p><b>Lot. de la b.L.</b> s. Le Lotus
+
+<p><b>M.</b> s. Ma1navadharmas4as4a1stra [pwj38]
+
+<p><b>Mac11.</b> s. Mas4aka Kalpasu1tra
+
+<p><b>Madanav.</b> s. Madanavinoda
+
+<p><b>Madanavinoda</b>
+<p>--...1. Ed. Benares, 1869. pw
+<p>--...2. Handschrift. pw
+
+<p><b>Ma1dhavak.</b> s. Ma1dhavaka1ra
+
+<p><b>Ma1dhavaka1ra</b>
+<p>--...Verfasser der Rugvinis4caya. PW
+
+<p><b>Ma1dhj. Rec.</b> s. S4atapathavra1hman2a
+
+<p><b>Ma1dh. Ka1lan2.</b> s. Ka1lanirn2aya
+
+<p><b>Madhus.</b> s. Madhusu1dhanasarasvati
+
+<p><b>Madhusu1danasarasvati</b> s. Indische Studien
+
+<p><b>Ma1ga</b> Über zwei Parteischriften zu Gunsten des Ma1ga, respektive
+S4a1kadvipi1ya Bra1hman2a. Von A. Weber. pw
+
+<p><b>Maha1bh.</b> s. Maha1bha1s2ya oder Maha1bha1rata
+
+<p><b>Maha1bha1rata</b>
+<p>--...1. Eine Bombayer und Calcuttaer Ausgabe. pw
+<p>--...2. Ed. Calcutta, 1834-39. [Gild. 93]. PW. Mit Harivam2s9a
+<p>--...3. Ed. Vardhama1na, Burdwan, 1784, 1803. [I.O. 1497] pw
+
+<p><b>Maha1bha1s2ya</b>
+<p>--...1. Eine Edition aus Benares. pw
+<p>--...2. Ed. F. Kielhorn, Bombay, 1880-85. [I.O. 185] pw
+<p>--...3. Erawähnt in Böhtlingks Pa1n2ini Ausgabe. PW
+
+<p><b>Maha1c11.</b> s. Maha1s4a1nti
+
+<p><b>Maha1n.</b> s. Maha1na1t2aka
+
+<p><b>Maha1na1ra1yan2a Upanis2ad</b>
+<p>--...Ohne weiteres im PW.
+
+<p><b>Maha1na1r. Up.</b> s. Maha1na1ra1yan2a Upanis2ad
+
+<p><b>Maha1na1t2aka</b>
+<p>--...Ed. K. Kr2s2n2a Bahadur, Calcutta, 1840. [Gild. 220] PW
+
+<p><b>Maha1s4a1nti</b>
+<p>--...Handschrift. pw
+
+<p><b>Maha1 Upanis2ad</b>
+<p>--...Ohne weiteres im PW.
+
+<p><b>Mahav.</b> s. Mahavi1racarita
+
+<p><b>Mahavi1racarita</b>
+<p>--...Ed. F. H. Tritten, London, 1848. [I.O. 1530] PW, pw
+
+<p><b>Mahavi1rak4.</b> s. Mahavi1racarita
+
+<p><b>Mahi1dh.</b> s. Mahi1dhara [pwj39]
+
+<p><b>Maha1dhara</b>
+<p>--...Ein Kommentator der Va1jasaneyisam2hita1. PW. pw
+
+<p><b>Mahop.</b> s. Maha1 Upanis2ad
+
+<p><b>Maitra1yan2i1 Paddhati</b>
+<p>--...Handschrift. pw
+
+<p><b>Maitra1yan2i1 Sam2hita1</b>
+<p>--...Ed. L. v. Schröder, Leipzig, 1881. [I.O. 1537] pw
+
+<p><b>Maitra1yan2i1 Upanis2ad</b>
+<p>--...1. Handschrift. PW || 2. Ed. E. B. Cowell, London, 1870. [I.O. 1538] pw
+
+<p><b>Maitrjup.</b> s. Maitra1yan2i1 Upanis2ad
+
+<p><b>Maitr. Paddh.</b> s. Maitra1yan2i1 Paddhati
+
+<p><b>Ma1jat.</b> s. Ma1yatantra
+
+<p><b>Malama1satattva</b>
+<p>--...75 Seiten. Nach Anführungen im S4KD. [Gild. 325] PW
+
+<p><b>Ma1lat. oder Ma1lati1m.</b> s. Ma1lati1ma1dhava
+
+<p><b>Ma1lati1ma1dhava</b>
+<p>--...1. Ed. Calcutta, 1830. [I.O. 1540] PW, pw
+<p>--...2. Ed. R. G. Bhandarkar, Bombay, 1876. [I.O. 1541] pw
+
+<p><b>Ma1lav.</b> s. Ma1lavi1ka1gnimitra
+
+<p><b>Ma1lavi1ka1gnimitra</b>
+<p>--...Ed. O. F. Tullberg, Bonn, 1840. [I.O. 1541] PW, pw
+
+<p><b>Mallin.</b> s. Mallina1tha
+
+<p><b>Mallina1tha</b>
+<p>--...Ein Kommentator des Ka9lida1sa. PW, pw
+
+<p><b>Ma1navadharmas4a1stra</b> s. Manu
+
+<p><b>Ma1navagr2hysu1tra</b>
+<p>--...Handschrift in der Univertitätsbibliothek Bombay. Mit Paddhati. pw
+
+<p><b>Ma1navakalasu1tra</b>
+<p>--...Ed. Th. Goldstücker, London, 1861. [I.O. 1552] PW, pw
+
+<p><b>Ma1nava S4rautasu1tra</b>
+<p>--...Handschrift. pw
+
+<p><b>Ma1n. C11r.</b> s. Ma1nava S4rautasu1tra
+
+<p><b>Ma1n2d2. C11ik2sha1</b> s. Ma1n2d2u1ki1 S4iks2a
+
+<p><b>Ma1n2d2u1kya Upanis2ad</b> s. Taittiri1ya Upanis2ad
+
+<p><b>Ma1n2d2u1ki1 S4iks2a</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>Ma1n2d2. Up.</b> s. Ma1n2d2u1kya Upanis2ad
+
+<p><b>Ma1n2d2a. Up. Ka1r.</b> s. Ma1n2d2u1kya Upanis2ad [pwj40]
+
+<p><b>Ma1n.Gr2hj.</b> s. Ma1nava Gr2hyasu1tra
+
+<p><b>Man4g4uc11ri1n.</b> s. A1ryaman5jus4ri1namasam2gi1ti
+
+<p><b>Ma1n. K.S.</b> s. Ma1nava Kalpasu1tra
+
+<p><b>Mantrabr.</b> s. Mantrabra1hman2a
+
+<p><b>Mantrabra1hman2a</b>
+<p>--...Vielleicht Ed. Calcutta. 1872. [I.O. 1574] pw
+
+<p><b>Manu</b> 1. Ma1nava dharmas4a1stra. Ed. A. L. Deslongchamps. Paris, 1833.
+[I.O. 1533] PW 2. The Institutes of Menu with the Commentary of Kullu1ka
+Bhat2t2a. Ed. Calcutta, 1830. [I.O. 1583] PW, pw
+
+<p><b>Ma1rkan2d2eya Pura1n2a</b>
+<p>--...Ed. K. M. Banerjea, Calcutta, 1855. 1862. [I.O. 1590] PW, pw
+
+<p><b>Ma1rk. P.</b> s. Ma1rkan2d2eya Pura1n2a
+
+<p><b>Mas4aka Kalpasu1tra</b>
+<p>--...Ohne weiteres im PW.
+
+<p><b>Materia indica</b>
+<p>--...of the Hindus. Von U. Ch. Dutt, Calcutta, 1877. pw
+
+<p><b>Mathura1n.</b> s. Mathura1na1t2ha
+
+<p><b>Mathura1na1tha</b>
+<p>--...Ein Scholiast des Amarakos4a. Nach Anführungen im S4KD. PW
+
+<p><b>Mat. ind.</b> s. Materia indica
+
+<p><b>Mat. med.</b> s. Materia medica
+
+<p><b>Matsja P.</b> s. Matsya Pura1n2a
+
+<p><b>Matsjop.</b> s. Matsyopa1khya1nam
+
+<p><b>Matsya Pura1n2a</b>
+<p>--...1. Handschrift. PW
+<p>--...2. Ed. R. Jana1rdana1ca1rya, Poona, 1874. [I.O. 1598]pw
+
+<p><b>Matsyopa1khya1nam.</b> s. Arjunasama1gama
+
+<p><b>Ma1ya1tantra</b>
+<p>--...Nach Anführungen im S4KD. PW
+
+<p><b>Mayr</b> s. Indisches Erbrecht
+
+<p><b>Mbh.</b> s. Maha1bha1rata
+
+<p><b>Med.</b> s. Medini1kos4a
+
+<p><b>Med. avj.</b> s. Avyaya1neka1rthavarga
+
+<p><b>Medha1tithi</b>
+<p>--...Ein Scholiast des S4a1kuntala. pw
+
+<p><b>Medini1kos4a</b> s. Ha1ra1vali
+
+<p><b>Megh.</b> s. Meghadu1ta [pwj41]
+
+<p><b>Meghadu1ta</b>
+<p>--...1. Ed. J. Gildemeister, Bonn, 1841. [Gild. 151] PW Mit S4r2n3ga1ratilaka
+<p>--...2. Ed. A. F. Stenzler, Breslau, 1874. [I.O. 1605] pw
+
+<p><b>Me4l. asiat.</b> = Me4langes asiatiques, tire4s du Bulletin
+historico-philologique de l'Acade4mie Impe4riale des Sciences de St.
+Pe4tersbourg. PW
+
+<p><b>Me4moire sur l'Inde</b> Me4moire geographique, historique et scientifique
+sur l'Inde etc. Von M. Reinaud, Paris, 1849. PW
+
+<p><b>Mi1ma1m2sa1</b> 1. The Aphorisms of the Mi1ma1m2sa1 Philosophy by Jaimini.
+Ed. J. R. Ballantyne, Allahabad, 1851. [I.O. 1617] PW 2. The Aphorisms of the
+Mi1ma1m2sa1 Philosophy by Jaimini. Ed. M. Nya1yaratna, Calcutta, 1873. 1889. [I.O. 1618] pw
+
+<p><b>Miscellaneous Essays</b>
+<p>--...Von H. T. Colebrooke, London, 1837. PW, pw
+
+<p><b>Mit.</b> s. Mita1ks2ara
+
+<p><b>Mita1ks2ara</b>
+<p>--...Ed. L. N. Nya1ya1lam2ka1ra, Calcutta, 1829. [I.O. 3096] PW, pw
+
+<p><b>M.K.S.</b> s. Ma1navakalpasu1tra
+
+<p><b>M. Müller, Re.</b> s. India
+
+<p><b>Molesw.</b> s. Molesworth
+
+<p><b>Molesworth</b> A Dictionary Murathee and English by J. T. Molesworth,
+Bombay, 1831. PW, pw
+
+<p><b>Monatsberichte</b>
+<p>--...der königlich preussischen Aka demie der Wissenschaften in Belin. pw
+
+<p><b>Mon.d.B.A.</b> s. Monatsberichte
+
+<p><b>Mr2cchakatika</b>
+<p>--...Ed. A. F. Stenzler, Bonn, 1846. [I.O. 1634] PW, pw
+
+<p><b>Mr2k4k4h.</b> s. Mr2cchakatika
+
+<p><b>Mudra1r.</b> s. Mudra1ra1ks2asa
+<p>--...1. Ed. T. Tarkava1caspati Bhat2t2a1ca1rya, Calcutta, 1926 (?). [I.O.
+1641] pw
+<p>--...2. Ed. Calcutta, 1831. [I.O. 1639] PW, pw
+
+<p><b>Mugdhabodha</b>
+<p>--...Von Vopadeva. Ed. O. Böhtlingk, St. Petersbourg, 1842. [I.O. 1842] PW, pw
+[pwj42]
+
+<p><b>Muir, J.</b> Sancrit Texts on the Origin and Progress of the Religions and
+Institutions of India. Von J. Muir, London, 1858, PW
+
+<p><b>Müller, SL</b> s. A History of Ancient Sanscrit Literature. Von Max
+Müller. 1859.
+
+<p><b>Mun2d2aka Upanis2ad</b> s. Taittiri1ya Upanis2ad
+
+<p><b>Mun2d2ama1la1t.</b> s. Mun2d2ama1la1tantra
+
+<p><b>Mun2d2ama1la1tantra</b>
+<p>--...Nach Anführungen im S4KD. PW
+
+<p><b>Mun2d2. Up.</b> s. Mun2d2aka Upanis2ad
+
+<p><b>N.</b> s. Nala
+
+<p><b>Ma1dabindu1panis2ad</b> s. Atharvan2a Upanis2ads
+
+<p><b>Na1dap. Up.</b> s. Na1dabindu1panis2ad
+
+<p><b>Na1ga1n.</b> s. Na1ga1nanda
+
+<p><b>Na1ga1nanda</b>
+<p>--...Nach zwei calcuttaer Ausgaben. pw
+
+<p><b>Naigh.</b> s. Naighan2t2ukakha1n2d2a
+
+<p><b>Naighn2t2ukakha1n2d2a</b> s. Nirukta
+
+<p><b>Nais4adacarita</b>
+<p>--...Ed. Calcutta. 1836. [Gild. 143] PW, pw
+
+<p><b>Naish.</b> s. Nais2adacarita
+
+<p><b>Nala</b>
+<p>--...1. Ed. H. Brockhaus, Leipzig, 1859. [I.O. 1694] PW (Somadeva)
+<p>--... 2. Ed. F. Bopp, Berlin, 1832. [Gild. 99] PW
+<p>--...3. In der Sanskrit Chresthomathie von O. Böhtlingk
+
+<p><b>Na1na1rthak.</b> = Na1na1rthakos4a
+<p>--...Eine Wortsammlung nach Anführungen im S4KD. PW
+
+<p><b>Na1r.</b> s. Na1ra1yana und Na1rada Dharmas4a1stra
+
+<p><b>Na1rada Dharmas4a1stra</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>Na1ra1yana</b>
+<p>--...Ein Scholiast des Sa1n2kha1yana Gr2hyasu1tra. PW
+
+<p><b>Na1ra1yanabhat2t2as Prayogaratna</b> s. Prayogaratna
+
+<p><b>Na1ra1yanacakravartin</b>
+<p>--...Ein Scholiast des Amarakos4a, nach Anführungen im S4KD. PW
+
+<p><b>Navarat.</b> s. Navaratna
+
+<p><b>Navaratna</b> s. Ka1vyasam2graha
+
+<p><b>Naxatra</b>
+<p>--...Die vedischen Nachrichten von den Naxatra. Von A. Weber,
+
+<p><b>Berlin, 1860. pw</b> [pwj43]
+
+<p><b>Nida1na Su1tra</b>
+<p>--...Ohne weiteres im PW und pw.
+
+<p><b>Nigh.</b> s. Nighantu
+
+<p><b>Nighan2t2u</b> s. Nirukta
+
+<p><b>Nighan2t2u Praka1s4a</b>
+<p>--...Von Ba1pu Ganga1dhara, Bombay, 1839. PW, pw
+
+<p><b>Nigh. Pr.</b> s. Nighantu Praka1s4a
+
+<p><b>Ni1l.</b> s. Ni1lakan2t2ha
+
+<p><b>Ni1lak.</b> s. Ni1lakan2t2ha
+
+<p><b>Ni1lakan2t2ha</b>
+<p>--...1. Ein Scholiast des Maha1bha1rata. PW
+<p>--...2. A Rational Refutation of the Hindu Philosophical Systems by Nehemiah
+Ni1lakan2t2ha S4a1stri1 Gore. Translated by F. E. hall, Calcutta, 1862. pw
+
+<p><b>Nilarudra Upanis2ad</b> s. Atharvan2a Upanis2ads
+
+<p><b>Ni1lar. Up.</b> s. Ni1larudra Upanis2ad
+
+<p><b>Nir.</b> s. Nirukta
+
+<p><b>Nirn2ajas.</b> s. Nirn2ayasindhu
+
+<p><b>Nirn2ayasindhu</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>Nirukta</b>
+<p>--...Von Ya1ska. Ed. R. Roth, Göttingen, 1852. [I.O. 1762] PW, pw Mit den
+Nighan2t2us
+
+<p><b>Ni1tipr.</b> s. Ni1tipradi1pa
+
+<p><b>Ni1tipradi1pa</b> s. Ka1vyasam3graha
+
+<p><b>Nja1jam.</b> s. Jaimini1yanya1yama1la1vista1ra
+
+<p><b>Nja1jas.</b> s. Nya1yasu1tra
+
+<p><b>Nj. K.</b> s. Nya1ya Kos4a
+
+<p><b>Notices</b> Notices of Sanscrit Manuscripts by Ra1jendrala1la Mitra. pw
+
+<p><b>Nr2sim3hata1pani1ya Upanis2ad</b> s. Atharvan2a Upanis2ads
+
+<p><b>NR2S. Up.</b> s. Nr2sim2hata1pani1ya Upanis2ad
+
+<p><b>Nya1ya Kos4a</b>
+<p>--...Ed. Bh. Jhalaki1kar, Bombay, 1875. [I.O. 1806] pw
+
+<p><b>Nya1ya Su1tra</b>
+<p>--...Von Gotama. || 1. Ed. V. Bhat2t2a1cha1rya, Calcutta, 1828. [I.O. 1813]
+PW, pw
+<p>--...2. Ed. J. Tarkapan5ca1nana, Calcutta, 1864-65. [I.O. 1813] pw
+
+<p><b>Old. Buddha</b> s. Oldenberg
+
+<p><b>Oldenberg, H.</b>
+<p>--...Buddha, Berlin, 1881. pw [pwj44]
+
+<p><b>Opp. Cat.</b> s. Oppert
+
+<p><b>Oppert</b> List of Sanscrit Manuscripts in private Libraries of Southern
+India. Compiled, arranged and indexed by G. Oppert. pw
+
+<p><b>Oudh</b> A Catalogue of Sanscrit Manuscripts. pw
+
+<p><b>Oxford</b>
+<p>--...Verzeichnis von Sanskrit Handschriften von Th. Aufrecht. pw
+
+<p><b>P.</b> s. Pa1n2ini1
+
+<p><b>Pa1c11akak.</b> s. Pa1s4akakevali1
+
+<p><b>Padap.</b> s. Padapa1tha
+
+<p><b>Padapa1tha</b> s. R2gveda
+
+<p><b>Paddhati</b> s. Ma1nava Gr2hyasu1tra
+
+<p><b>Padya1vali1</b>
+<p>--...Handschrift. pw
+
+<p><b>Pan5cadan2d2acchattraprabandha</b>
+<p>--...Ed. A. Weber, Berlin, 1877. [I.O. 1838] pw
+
+<p><b>Pan5cara1tra</b>
+<p>--...Von Na1rada. Ed. K. M. Banerjea, Calcutta, 1861-65 [I.O. 1718] pw
+
+<p><b>Pan5catantra</b>
+<p>--...1. Ed. J. G. Kosegarten, Bonn, 1848-59. [I.O. 1858] PW, pw
+
+<p>--...2. Ed. F. Kielhorn, Bombay, 1868-96. [I.O. 1858] pw
+
+<p><b>Pan5cavim2s4a Bra1hman2a</b>
+<p>--...Ohne weiteres im PW.
+
+<p><b>Pa1n2ini</b>
+<p>--...Ed. O. Böhtlingk, Bonn, 1840. PW, pw Mit: Va1rtika1s von Ka1tya1yana,
+Gan2apa1thas, Gan2aratnamahodaddhi von Vardama1na, Erwähnung der Ka1s4ika1
+Vr2tti [Gild. 244], Excerpten aus dem Maha1ba1s2ya.
+
+<p><b>Pan4k4ad.</b> s. Pan5cadan2d2acchattraprabandha
+
+<p><b>Pan4k4ar.</b> s. Pan5cara1tra
+
+<p><b>Pan4k4at.</b> s. Pan5catantra
+
+<p><b>Pan4k4av. Br.</b> s. Pan5cavim2s4a Bra1hman2a
+
+<p><b>Para1c11.</b> s. Para1s4ara Dharmas4a1stra
+
+<p><b>Para1c11arapaddh.</b> s. Para1s4arapaddhati
+
+<p><b>Paramaham2sa Upanis2ad</b> s. Atharvan2a Upanis2ads
+
+<p><b>Parama1rthasa1ra</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>Param. Up.</b> s. Paramaham2sa Upanis2ad
+
+<p><b>Para1s4ara Dharmas4a1stra</b>
+<p>--...Nach Anführungen im Mit., Da1j. und S4KD. PW, pw [pwj45]
+
+<p><b>Para1s4ara Paddhati</b>
+<p>--...Ohne weiteres im PW.
+
+<p><b>Para1skara Gr2hyasu1tra</b>
+<p>--...1. Handschrift. PW. || 2. Ed. A. F. Stenzler, Leipzig, 1876-78. [I.O.
+1887] pw
+
+<p><b>Pa1r. Gr2hj.</b> s. Para1skara Gr2hyasu1tra
+
+<p><b>Paribh.</b> s. Paribha1s2endus4ekhara
+
+<p><b>Paribha1s2endus4ekhara</b>
+<p>--...Ed. F. Kielhorn, Bombay, 1868-74. [I.O. 1893]pw
+
+<p><b>Paris4is2t2aparvan</b>
+<p>--...Von Hemacandra. Handschrift. pw
+
+<p><b>Paris4is2t2a zum Atharvaveda</b>
+<p>--...Handschrift. PW, pw
+
+<p><b>Pa1rs4vana1thaka1vya</b>
+<p>--...Handschrift. pw
+
+<p><b>Pat.</b> s. Patan5jali
+
+<p><b>Patan5jali</b>
+<p>--...1. Verfasser des Maha1bha1s2ya. In Böhtlingks Pa1n2ini.
+<p>--... 2. s. Yogasu1tra
+
+<p><b>Patja1patjav.</b> s. Patya1patyaviveka
+
+<p><b>Pent. (Lassen)</b> s. Commentatio
+
+<p><b>Phit2su1tra</b>
+<p>--...Von S4a1ntanava. Ed. F. Kielhorn, Leipzig, 1866. [I.O. 1915] pw
+
+<p><b>Pin2d2apitr2yajn5a</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>Pin2d2op.</b> s. Pin2d2opanis2ad
+
+<p><b>Pin2d2opanis2ad</b> s. Atharvan2a Upanis2ads
+
+<p><b>Pischel</b> s. Hemacandras Prakrit Grammatik
+
+<p><b>Prabodhacandrodaya</b>
+<p>--...Ed. H. Brockhaus, Leipzig, 1835. [I.O. 1926] PW, pw
+
+<p><b>Pracan2d2apa1n2d2ava</b>
+<p>--...Ein Schauspiel. Handschrift. pw
+
+<p><b>Prac11nop.</b> s. Pras4na Upanis2ad
+
+<p><b>Pra1jac11k4ittav.</b> s. Pra1yas4cittaviveka
+
+<p><b>Praja1pati</b>
+<p>--...Nach Zitaten in verschiedenen juristischen Werken. pw
+
+<p><b>Prajogar.</b> s. Pragogaratna
+
+<p><b>Prakriya1 Kaumudi1</b>
+<p>--...Handschrift. pw
+
+<p><b>Prasannar.</b> s. Prasannara1ghava [pwj46]
+
+<p><b>Prasannara1ghava</b>
+<p>--...Von Jayadeva. pw
+
+<p><b>Pras4na Upanis2ad</b> s. Taittiri1ya Upanis2ad
+
+<p><b>Prastha1nabheda</b> s. Indische Studien
+
+<p><b>Pra1t.</b> = Pra1tis4a1khya
+
+<p><b>Prata1par.</b> s. Prata1parudri1ya
+
+<p><b>Prata1parudri1ya</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>Pratinj5a1su1tra</b> s. Indische Studien
+
+<p><b>Pra1tis4a1khya zur Taittiri1ya Sam2hita1</b>
+<p>--...1. Ed. W. D. Whitney, New Haven, 1871. [I.O. 2691] pw
+<p>--...2. In der einleitung von Roths Nirukta. PW, pw
+
+<p><b>Pra1tis4a1khya zur Va1jasaneisam2hita1</b>
+<p>--...1. Handschrift. PW || 2. s. Indische Studien
+
+<p><b>Pratyabdas4uddhi</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>Pravar.</b> s. Pravara1dhya1ya
+
+<p><b>Pravara1dhya1ya</b> Ohne weiteres im PW.
+
+<p><b>Pra1s4cittatattva</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>Pra1yas4cittaviveka</b>
+<p>--...Handschrift. pw
+
+<p><b>Pra1ys4citta zum Atharvaveda</b>
+<p>--...Handschrift. pw
+
+<p><b>Prayo1garatna</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>Prij1.</b> s. Priyadars4ika1
+
+<p><b>Priyadars4ika1</b>
+<p>--...Ed. J. Vidya1sa1gara, Calcutta, 1874. [I.O. 1988] pw
+
+<p><b>Procc. A.S.B.</b> = Proceedings of the Asiatic Society of Bengal.
+
+<p><b>Pr. P.</b> s. Pracan2d2apa1n2d2ava
+
+<p><b>Pur.</b> = Pura1n2a
+
+<p><b>Purush.</b> s. Purusottama
+
+<p><b>Purus2ottama</b>
+<p>--...Ein Lexikograph. PW
+
+<p><b>Pushpas.</b> s. Pus2pasu1tra
+
+<p><b>Pus2pasu1tra</b>
+<p>--...Ohne weiteres im PW und pw. [pwj47]
+
+<p><b>R.</b> s. Ra1ma1yana
+
+<p><b>Radices</b>
+<p>--...linguage sanscritae. Von W. L. Westergaard, Bonn, 2841. PW, pw
+
+<p><b>Ra1g4an.</b> s. Ra1janighan2t2u
+
+<p><b>Ra1g4at.</b> s. Ra1jataran3nini1
+
+<p><b>R1g4av.</b> s. Ra1javallabha
+
+<p><b>Ragh.</b> s. Raghuvam3s4a
+
+<p><b>Raghun.</b> s. Raghuna1ndanabhat2t2a1ca1rya
+
+<p><b>Raghuna1ndanbhat2t2a1ca1rya</b>
+<p>--...Ein Scholiast des Tithya1ditattva. PW
+
+<p><b>Raghuvam2s4a</b>
+<p>--...1. Ed. Calcutta, 1832. [Gild. 134] PW, pw
+<p>--...2. Ed. A. F. Stenzler, London, 1832. [I.O. 2034] PW, pw
+
+<p><b>Ra1jam.</b> s. Ra1yamukuta
+
+<p><b>Ra1janighan2t2u</b>
+<p>--...1. Ed. R. Garbe, Leipzig, 1882. [I.O. 2055] pw
+<p>--...2. Nach Anführungen im S4KD. PW
+
+<p><b>Ra1jataran3gini1</b>
+<p>--...1. Ed. Calcutta, 1835. [Gild. 147] PW
+<p>--...2. Ed. M. A. Troyer, Paris, 1840-52. [I.O. 2059] PW, pw
+<p>--...3. Ed. Kern, pw.
+
+<p><b>Ra1javallabha</b>
+<p>--...Nach Zitaten im S4KD. PW, pw
+
+<p><b>Ra1jendr. Not.</b> s. Notices
+
+<p><b>Ra1man.</b> s. Ra1mana1tha
+
+<p><b>Ra1mana1tha</b>
+<p>--...Ein Kommentator des Amarakos4a. Nach Anfürungen im S4KD. PW
+
+<p><b>Ra1mapu1rvat. Up.</b> s. Ra1mapu1rvata1pani1ya Upanis2ad
+
+<p><b>Ra1mapu1rvata1pani1ya Upanis2ad</b> s. Atharvan2a Upanis2ads
+
+<p><b>Ra1matarkav.</b> s. Ra1matarkavagi1s4a
+
+<p><b>Ra1matarkavagi1s4a</b>
+<p>--...Eine Prakrit Grammtik. pw
+
+<p><b>Ra1mata1pani1ya Upanis2ad</b>
+<p>--...Ed. A. Weber, Berlin, 1864. pw
+
+<p><b>Ra1ma1yan2a</b>
+<p>--...1. Ed. G. Gorresio, Paris, 1843. [I.O. 2111] PW, pw
+<p>--...2. Ed. A. W. Schlegel, Bonn, 1829-33. [I.O. 2111] PW, pw
+
+<p><b>Rasam.</b> s. Rasaman5jari1 [pwj48]
+
+<p><b>Rasaman5jari1</b>
+<p>--...Nach Anführungen im S4KD. Verz. der Berliner Sanskrit Handschriften Nr.
+597. PW
+
+<p><b>Rasar.</b> s. Rasaratna1kara
+
+<p><b>Rasaratna1kara</b>
+<p>--...Ed. R. Gu1ha, Calcutta, 1878. [I.O. 2148] pw
+
+<p><b>Ra1shtrapa1lap.</b> s. Ra1s2t2rapa1lapariprccha1
+
+<p><b>Ra1s2t2rapa1lapariprccha1</b>
+<p>--...Handschrift in der Pariser Bibliothek. Nach Schiefner. PW
+
+<p><b>Ratim.</b> s. Ratiman5jari1
+
+<p><b>Ratiman5jari1</b>
+<p>--...Ein Werk über Erotik. Nach Anführungen im S4KD. PW
+
+<p><b>Ratnak.</b> s. Ratnakos4a
+
+<p><b>Ratnakos4a</b>
+<p>--...Ein Wörterbuch, nach Anführungen im S4KD. PW
+
+<p><b>Ratnam.</b> s. Ratnama1la1
+
+<p><b>Ratnama1la1</b>
+<p>--...Ein Wörterbuch, nach Anführungen im S4KD. PW
+
+<p><b>Ratna1v.</b> s. Ratnama1la1
+
+<p><b>Ratna1ali1</b>
+<p>--...Ed. Calcutta, 1832. [Gild. 214] PW
+
+<p><b>Ra1yamukuta</b>
+<p>--...Ein Kommentator des Amarakos4a, nach Anführungen im S4KD. PW
+
+<p><b>Report</b> s. Kielhorn
+
+<p><b>R2gveda</b>
+<p>--...1. Ed. F. Rosen, 1. Buch, London, 1838. [I.O. 2177] PW
+<p>--...2. Handschrift. PW, pw Mit Pra1tis4a1khya, Anu3kraman2ika1, Sa1yan2as
+Kommentar.
+
+<p><b>R2ktantra</b>
+<p>--...Ed. A. C. Burnell, Bangalore, 1879. [I.O. 2194] pw
+
+<p><b>Roxb.</b> s. Roxburg
+
+<p><b>Roxburg</b> s. Flora indica
+
+<p><b>R2t.</b> s. R2tusam2ha1ra
+
+<p><b>R2tusam2ha1ra</b>
+<p>--...Ed. P. A. Bohlen, Leipzig, 1840. [I.O. 2201] PW, pw
+
+<p><b>Rudrata1lam2ka1rat2ippanaka</b>
+<p>--...Ein Werk über Poetik. pw
+
+<p><b>R2v.</b> s. R2gveda
+
+<p><b>S4abdacandrika1</b>
+<p>--...Ein Wörterbuch, nach Anführungen imS4KD. PW, pw [pwj49]
+
+<p><b>S4abdakalpadruma</b>
+<p>--...Von Ra1dha1ka1ntadeva, 1743-1766. PW, pw
+
+<p><b>S4abdama1la1</b>
+<p>--...Ein wörterbuch, nach Anfürungen im S4KD. PW
+
+<p><b>S4abdaratna1vali1</b>
+<p>--...Ein Wörterbuch, nach Anführungen im S4KD. PW
+
+<p><b>Saddh.</b> s. Saddharmapun2d2ari1ka
+
+<p><b>Sadharmalan3ka1vata1ra</b>
+<p>--...Ohne weiteresim PW.
+
+<p><b>Saddharmapun2d2ari1ka</b>
+<p>--...1. Hundschrift, nach Schiefner. PW
+<p>--...2. Im 4. Kapitel von "Le Lotus de la bonne Lois. " Ed. E. Foucaux, Paris,
+1854. PW, pw
+
+<p><b>Saddh. L.</b> s. Saddharmalan3ka1vata1ra
+
+<p><b>Saduktikarn2a1mr2ta</b>
+<p>--...Von S4ri1dharada1sa, Handschrift. pw
+
+<p><b>S4advim2s4a Bra9hmn2a</b>
+<p>--...Ohne weiteres im PW und pw.
+
+<p><b>Sa1h. D.</b> s. Sa1hitya Darpana
+
+<p><b>Sa1hitya Darpana</b>
+<p>--...1. Ed. E. Röer, Calcutta, 1850. [I.O. 2247] PW, pw
+<p>--... 2. Ed. Calcutta, 1828. [Gild. 264] pw
+
+<p><b>Sahr2daya1loka</b>
+<p>--...2. Ed. Calcutta, 1828. [Gild. 264] pw
+
+<p><b>Sahr2daya1loka</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>Sa1j.</b> s. Sa1yan2a
+
+<p><b>S4a1kata1yana</b>
+<p>--...Ein Scholiast des S4a1kuntala. PW
+
+<p><b>Sa1kta1nandataran3gin2i1</b>
+<p>--...Handschrift. pw
+
+<p><b>S4a1kuntala</b>
+<p>--...1. Ed. A. L. Che4zy, Paris, 1830. [I.O. 8] PW
+<p>--...2. Ed. O. Böhtlingk, Bonn, 1842. [I.O. 8] PW, pw
+<p>--...3. Ed. R. Pischel, London, 1877. [I.O. 9] pw
+<p>--...4. Ed. K. Burkhard, Wien, 1884. [I.O. 10] pw
+<p>--...5. Ed. p. Tarkavagi1s4a, Calcutta, 1859-60. [I.O. 15] [pw
+
+<p><b>Sa1maveda</b>
+<p>--...Ed. Th. Benfey, Leipzig, 1848. [I.O. 2268] PW, pw [pwj50]
+
+<p><b>Sa1mav. br.</b> s. Sa1mavidha1na Bra1hman2a
+
+<p><b>Sa1mavidha1na Bra1hman2a</b>
+<p>--...Ed. A. c. Burnell, London, 1873. [I.O. 2273] pw
+
+<p><b>Sam2gi1tada1mod.</b> s. Sam2gi1tada1modara
+
+<p><b>Sam2gi1tada1modara</b>
+<p>--...Ein Werküber Musik, nach Anführungen im S4KD. PW
+
+<p><b>Sam2gi1tasa1rasam2graha</b>
+<p>--...Ed. A. C. Thakura, Calcutta, 1832. [I.O. 2273] pw
+
+<p><b>Sam2hita1 Upanis2ad</b>
+<p>--...Ed. A. C. Burnell, Mangalore, 1877. [I.O. 2291] pw
+
+<p><b>Sam2hitop.</b> s. Sam2hita1 Upanis2ad
+
+<p><b>S4am2kara</b>
+<p>--...1. Ein Scholiast des S4a1kuntala. PW
+<p>--...2. Ein Kommentator der Brahmasu1tras.
+
+<p><b>S4am2karavijaya</b>
+<p>--...Ed. J. Pan5ca1nana, Calcutta, 1864-68. [I.O. 2308] pw
+
+<p><b>Sa1m2khjak.</b> s. Sa1m2khya Ka1rika1
+
+<p><b>Sa1m2khya Ka1rika1</b>
+<p>--...1. Ed. Chr. Lassen, Bonn, 1832. [Gild. 270] PW
+<p>--...2. Ed. H. H. Wilson, London, 1837. [I.O. 2312] PW, pw
+
+<p><b>Sa1m2khya Philosophie</b>
+<p>--...The Aphorisms of the Sa1m2khya Philosophy of Kapila. Ed. J. R. Ballantyne,
+Allahabad, 1852. 1854. [I.O. 2315] PW, pw
+
+<p><b>Sam2ks2epas4am2karajaya</b>
+<p>--...Von Ma1dhava. pw
+
+<p><b>Sam2n5a1sa Up.</b> s. Atharvan2a Upanis2ads
+
+<p><b>Sam2n5j. Up.</b> s. Sam2n5a1sa Up.
+
+<p><b>Sam2ska1rakaustubha</b>
+<p>--...Von Anantadeva. pw
+
+<p><b>Sam2ska1rat.</b> s. Sam2ska1ratattva
+
+<p><b>Sam2ska1ratattva</b>
+<p>--...Nach Anführungen im S4KD. PW
+
+<p><b>Sam2skk.</b> s. Sam2ska1rakaustubha
+
+<p><b>S4a1ndilya</b> The Aphorisms of S4a1ndilya. Ed. E. B. Cowell, Calcutta,
+1878. [I.O. 391] pw
+
+<p><b>S4a1n3kha1yana Bra1hman2a</b>
+<p>--...Ohne weiteres im PW und pw.
+
+<p><b>S4a1n3kha1yana Gr2hyasu1tra</b>
+<p>--...1. Ed. H. Oldenberg, Oxford, 1886. [I.O 967] pw
+<p>--...2. Handschrift. PW. [pwj51]
+
+<p><b>S4a1n3kha1yana S4rautasu1tra</b>
+<p>--...Ohne weiteres im PW und pw.
+
+<p><b>Sanskrit Chresthomathie</b>
+<p>--...Von O. Böhtlingk, St. Petersburg, 1845. [I.O. 2356] PW, pw Mit:
+Das4arathas Tod, Geschichte des Vidu1s4aka.
+
+<p><b>Sanscrit Texts</b> s. Muir
+
+<p><b>S4a1ntana1ca1rya Phit2su1tra</b>
+<p>--...Ed. O. Böhtlingk, St. Petersburg, 1848. pw
+
+<p><b>S4a1ntanava</b> s. Phit2su1tra
+
+<p><b>S4a1ntis4ataka</b> s. Ka1vyasam2graha
+
+<p><b>Saptas4ataka</b>
+<p>--...Von Ha1la. Ed. A. Weber, Leipzig, 1870. [I.O. 2365] pw
+
+<p><b>Saptas4ati1</b>
+<p>--...Von Govardhana. pw
+
+<p><b>Sa1ras.</b> s. Sa1rasundari
+
+<p><b>Sa1rasundari</b>
+<p>--...Ein Kommentator des Amarakos4a. PW, pw
+
+<p><b>Sarasvati1kan2t2ha1bharan2a</b>
+<p>--...1. s. Va1gbhatas Alam2ka1ra
+<p>--...2. Handschrift. pw
+
+<p><b>Sa1ra1v.</b> s. Sa1ra1vali1
+
+<p><b>Sa1ra1vali1</b>
+<p>--...Von Utpala. Es wird Vara1hmihiras Br2hatsam2hita1 zitiert. pw
+
+<p><b>S4a1rn3gadharapaddhati</b>
+<p>--...Handschrift im St. Petersburger asiatischen Museum der kaiserlichen
+Akademie der Wissenschaften. Auch nach Mitteilungen von Aufrecht. pw
+
+<p><b>S4a1rn3gadhara Sam2hita1</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>Sarvad.</b> s. Sarvadars4anasam2graha
+
+<p><b>Sarvadars4anasam2graha</b>
+<p>--...Ed. J. Vidya1sa1gara, Calcutta, 1853-58. [I.O. 2391] pw
+
+<p><b>Sarvop. S.</b> s. Sarvopanis2atsa1ra
+
+<p><b>Sarvopanis2atsa1ra</b> s. Atharvan2a Upanis2ads
+
+<p><b>S4a1s4vata</b> s. Aneka1rthasamuccaya
+
+<p><b>S4atapatha Bra1hman2a</b> s. Yajurveda
+
+<p><b>S4atarudri1ya Upanis2ad</b>
+<p>--...Ohne weiteres im PW.
+
+<p><b>S4atrum2jayamaha1tmya</b>
+<p>--...Ed. A. Weber, Leipzig, 1858. [I.O. 2421] PW, pw [pwj52]
+
+<p><b>S4aun.</b> s. S4auna1ga
+
+<p><b>S4auna1ga</b>
+<p>--...Inder Einleitung zu Böhtlingks Pa1n2ini Ausgabe, S. 66. PW, pw
+
+<p><b>Sa1v.</b> s. Sa1vitri1
+
+<p><b>Sa1vitri1</b> s. Arjunasama1gama
+
+<p><b>Sa1yan2a</b>
+<p>--...Ein Kommentator zum R2gveda. PW, pw
+
+<p><b>Sch. oder Schol.</b> = Scholiast
+
+<p><b>Select Specimens</b>
+<p>--...of the Theatre of the Hindus. Von H. H. Wilson, London, 1835. [I.O. 2448]
+PW, pw
+
+<p><b>Setub.</b> s. Setubandha
+
+<p><b>Setubandha</b> Ra1van2avadha oder Setubandha. Ed. S. Goldschmidt, London,
+1880. [I.O. 2451] pw
+
+<p><b>Siddha1ntam.</b> s. Siddha1ntamukta1vali1
+
+<p><b>Siddha1ntamukta1vali1</b>
+<p>--...Nach anführungen im S4KD. PW
+
+<p><b>Siddha1ntas4iroman2i</b>
+<p>--...Von BHa1skara. Ed. B. Sa1stri, Benares, 1866. [I.O. 2468] PW, pw Mit:
+Gola1dhya1ya, Gan2itadhya1ya.
+
+<p><b>Siddh. C11ir.</b> s. Siddha1ntas4iroman2i
+
+<p><b>Siddh. K.</b> s. Langhukaumudi1
+
+<p><b>S4i1la1n3ka</b> s. A1ca1ra1n3gasu1tra
+
+<p><b>S4is4upa1lavadha</b>
+<p>--...Von Ma1gha. Ed. V. Mis4ra, S. La1la, Calcutta, 1815. [Gild. 141] PW, pw
+
+<p><b>S4ivana1masahasra</b>
+<p>--...Handschrift im asiatischen Museum der kaiserlichen Akadamie der
+Wissenschaften zu St. Petersburg. PW
+
+<p><b>S4iva Pura1n2a</b>
+<p>--...Handschrift Nr. 126 im Verzeichnis der Oxforder Sansc. hds. pw
+
+<p><b>S4iva Upanis2ad</b> s. Atharvan2a Upanis2ads
+
+<p><b>Skanda P.</b> s. Skanda Pura1n2a
+
+<p><b>Skanda Pura1n2a</b>
+<p>--...Ohne weiteres im PW.
+
+<p><b>S4KD</b> = S4abdakalpadruma
+
+<p><b>Smaradi1pika1</b>
+<p>--...Ein Wörterbuch über Erotik, Nach Anführungen im S4KD. PW [pwj53]
+
+<p><b>S4obhanastuti</b>
+<p>--...von s4obhanamuni. In: z. d. d. m. G., 32, 509 ff. pw
+
+<p><b>Somadevas Nala</b> s. Nala
+
+<p><b>Somakarmapr.</b> s. Somakarmapradi1pa
+
+<p><b>Somakarmapradi1pa</b>
+<p>--...Von Ra1ma. Handschrift. pw
+
+<p><b>Som. Nal.</b> s. Somadevas Nala
+
+<p><b>Spr.</b> s. Indische Sprüche
+
+<p><b>S4ra1ddhatattva</b>
+<p>--...Nach Anführungen im S4KD. pw
+
+<p><b>S4ri1dharasva1min</b>
+<p>--...Nach Anführungen im S4KD. PW
+
+<p><b>S4ri1dharasva1min</b>
+<p>--...Ein Scholiast der Bhagavadgi1ta1. PW
+
+<p><b>S4ri1mi1la1maha1tmya</b>
+<p>--...Handschrift im pw.
+
+<p><b>S4r2n3ga1ratilaka</b> s. Meghadu1ta
+
+<p><b>S4rutabodha</b>
+<p>--...Ed. H. Brockhaus, Leipzig, 1841. PW, pw
+
+<p><b>s.s.s.</b> s. Sam2gi1tasa1rasam2graha
+
+<p><b>St.</b> = Stenzler
+
+<p><b>St. Petersburg</b> Verzeichnis der Petersburger Sanskr. Hds. von O.
+Böhtlingk, 1846.
+
+<p><b>Subh.</b> s. Subhu1ti
+
+<p><b>Subha1shitar.</b> s. Subha1s2itaratna1kara
+
+<p><b>Subha1s2itaratnabha1n2d2a1yaka</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>Subha1s2itaratna1kara</b>
+<p>--...Ed. K. S. Bha1t2avadekar, Bombay, 1871. [I.O. 2625] pw
+
+<p><b>Subha1s2ita1vali1</b>
+<p>--...Von Vallabhadeva. Handschrift. pw
+
+<p><b>Subhu1ti</b>
+<p>--...Ein Scholiast des Amarakos4a, Nach Anführungen im S4KD. PW
+
+<p><b>Suc11r.</b> s. Sus4ruta
+
+<p><b>S4ukhab.</b> s. S4ukhabodha
+
+<p><b>Sukhabodha</b>
+<p>--...Nach Anführungen im S4KD. PW
+
+<p><b>S4ukasam2des4a</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>S4ukasaptati</b> s. Anthologia sanscritica [pwj54]
+
+<p><b>Sukha1v.</b> s. Sukha1vativyu1ha
+
+<p><b>Sukha1vativyu1ha</b>
+<p>--...Ed. M. Müller, Oxford, 1833. [I.O. 2641] pw
+
+<p><b>S4ukrani1ti</b>
+<p>--...E. G. O. Oppert, Madras, 1882. [I.O. 2644] pw
+
+<p><b>S4ulva Su1tra</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>Sund.</b> s. Sundopasundopa1khya1na
+
+<p><b>Sundopasundopa1khya1na</b> s. Indraloka1gamana
+
+<p><b>Suparn2.</b> s. Suparn2a1dhya1ya
+
+<p><b>Suparn2a1dhya1ya</b> s. Indische Studien
+
+<p><b>Su1rjad.</b> s. Su1ryadevayajvan
+
+<p><b>Su1rjas.</b> s. Su1ryasiddha1nta
+
+<p><b>Su1ryadevayajvan</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>Su1ryasiddha1nta</b>
+<p>--...1. Nach Anführungen in Haughtons Wörterbuch. PW
+<p>--...2. Ed. B. D. S4a1stri1, Calcutta, 1861. [I.O. 2661] pw
+
+<p><b>Sus4ruta</b>
+<p>--...1. Ed. F. Hessler, Erlangen, 1844. [Gild. 368] PW, pw
+<p>--...2. Ed. M. Gupta, Calcutta, 1835. [Gild. 367] PW, pw
+
+<p><b>Suvarn2apr.</b> s. Suvarn2aprabha1s2a
+
+<p><b>Suvarn2aprabha1s2a</b>
+<p>--...Ein Buddhistisches Werk. PW
+
+<p><b>SV.</b> s. Sa1maveda
+
+<p><b>Svapnacinta1man2i1</b>
+<p>--...Von Jagaddeva. pw
+
+<p><b>Svapnak4.</b> s. Svapnacinta1man2i1
+
+<p><b>SV. A1r.</b> s. A1ran2yaka zum Sa1maveda
+
+<p><b>S4veta1s4vatara Upanis2ad</b> s. Taittiri1ya Upanis2ad
+
+<p><b>Taitt. A1r.</b> s. Taittiri1ya A1ran2yaka
+
+<p><b>Taitt. Br.</b> s. Taittiri1ya Bra1hman2a
+
+<p><b>Taittiri1ya A1ran2yaka</b>
+<p>--...Ed. R. Mitra, Calcutta, 1864. 1872. [I.O. 2689] PW, pw
+
+<p><b>Taittiri1ya Bra1hman2a</b>
+<p>--...Ohne weiteres im PW und pw.
+
+<p><b>Taittiri1ya Sam2hita1</b>
+<p>--...Handschrift. PW, pw Mit: Pra1tis4a1khya und Anukraman2ika1 [pwj55]
+
+<p><b>Taittiri1ya Upanis2ad</b>
+<p>--...Ed. E. Röer. Calcutta, 1853. [I.O. 2802] PW, pw Mit: Taittiri1ya Up.,
+Mun2d2aka Up., Fras4a Up., I1s4a Up., Kena Up., Kat2ha Up., Cha1ndogya Up., Aitareya Up., Sveta1s4vatara Up.
+
+<p><b>Taitt. Pra1t.</b> s. Taittiri1ya Sam3hita1 und Pra1tis4a1khya zur Taitt.
+Sam2.
+
+<p><b>Taitt. Up.</b> s. Taittiri1ya Upanis2ad
+
+<p><b>Talavaka1ra Bra1hman2a</b>
+<p>--...Ed. A. C. Burnell, Mangalore, 1878. [I.O. 162] pw
+
+<p><b>Tal. Br.</b> s. Talavaka1ra Bra1hman2a
+
+<p><b>Ta1n2d2j. Br.</b> s. Ta1n2d2ya Bra1hman2a
+
+<p><b>Ta1n2d2ya Bra1hman2a</b>
+<p>--...Ed. A. Veda1ntava1gi1s4a, Calcutta, 1869-74. [I.O. 1864] pw
+
+<p><b>Tantras.</b> s. Tantrasa1ra
+
+<p><b>Tantrasa1ra</b>
+<p>--...Nach Anführungen im S4KD. PW
+
+<p><b>Tattvakaumudi1</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>Tattvas.</b> s. Tattvasama1sa
+
+<p><b>Tattvasama1sa</b>
+<p>--...A Lecture on the Sa1m2khya Philosophy. Ed. J. R. Ballantyne, Mirzapore,
+1850. [I.O. 2739] PW, pw
+
+<p><b>T.Br.</b> s. Taittiri1ya Bra1hman2a
+
+<p><b>Teg4ob.</b> s. Tejobindu1panis2ad
+
+<p><b>Tejobindu1panis2ad</b> s. Atharvan2a Upanis2ads
+
+<p><b>Tibetische Lebensbeschreibung</b> s. Lebensbeschreibung
+
+<p><b>Tib. Lebensb. C11a1kj.</b> s. Tibetische lebensbeschreibung
+
+<p><b>Tithja1dit.</b> s. Tithya1ditattva
+
+<p><b>Tithya1ditattva</b>
+<p>--...Nach Anführungen im S4KD. PW
+
+<p><b>Trans. R.A.S.</b> = The Transactions of the Royal Asiatic Society of Great
+Britain and Ireland,. Nach Anführungen bei Haughton. PW
+
+<p><b>Trik.</b> s. Trika1n2d2as4es4a
+
+<p><b>Trika1n2d2as4es4a</b>
+<p>--...Ed. H. T. Colebrooke, Calcutta, 1807. [Gild. 258] PW, pw
+
+<p><b>Tripras4na1dhika1ra</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>TS.</b> s. Taittiri1ya Sam2hita1
+
+<p><b>TS. Anukr.</b> s. Taittiri1ya Sam2hita1
+
+<p><b>TS. Pra1t.</b> s. Pra1tis4a1khya zur Taittiri1ya Sam2hita1 [pwj56]
+
+<p><b>Udva1hat.</b> s. Udva1hatttva
+
+<p><b>Udva1hatattva</b>
+<p>--...nach Anführungen im S4KD. pw
+
+<p><b>Ug4g4val.</b> s. Ujjvaladatta
+
+<p><b>Ujjvaladatta</b> s. Un2a1disu1tras
+
+<p><b>Un2.</b> s. Un2a1di Affixe
+
+<p><b>Un2a1di Affixe</b>
+<p>--...Ed. O. Böhtlingk, St. Petersburg, 1844. [I.O. 2788] PW
+
+<p><b>Un2a1dik.</b> s. Un2a1dikos4a
+
+<p><b>Un2a1dikos4a</b>
+<p>--...Nach Anführungen im S4KD. PW
+
+<p><b>Un2a1dis.</b> s. Un2a1disu1tra
+
+<p><b>Un2a1disu1tra</b> Ujjvalas Kommentar zu den Un2a1disu1tras. Ed. Th.
+Aufrecht, London, 1859. [I.O. 2789] pw
+
+<p><b>Up. und Upak.</b> s. Upakos4a
+
+<p><b>Upag. Av.</b> s. Upagupta1vada1na
+
+<p><b>Upagupta1vada1na</b>
+<p>--...Handschrift in der Pariser Bibliothek. PW Nach Schiefner.
+
+<p><b>Upakos4a</b> Gründung der Stadt Pataliputra und Geschichte der Upakos4a.
+Fragmente aus Somadevas Katha1sritsa1gara. Ed. H. Brockhaus, Leipzig, 1835. PW
+
+<p><b>Upal.</b> s. Upalekha
+
+<p><b>Upalekha</b>
+<p>--...Ed. W. Pertsch, Berlin, 1854. [I.O. 2796] PW
+
+<p><b>Uttaracaritrakatha1nakam</b>
+<p>--...In: Sitzungsberichte der königlich oreuss. Ak. der Ww. zu berlin, 1884,
+Nr. 17. pw
+
+<p><b>Uttarar.</b> s. uttarara1macarita
+
+<p><b>Uttarara1macarita</b>
+<p>--...1. Ed. Calcutta, 1831. [I.O. 2830] PW, pw
+<p>--...2. Ed. P. tarkavagi1s4a, Calcutta, 1862. [I.O. 2832] pw
+
+<p><b>Utt. Ra1ma K.</b> s. Uttarara1macarita
+
+<p><b>Va1ghbhat2t2as Alam2ka1ra</b>
+<p>--...Ed. A. Boroah, London, Calcutta, 1883. [I.O. 1316] pw Mit:
+Sarasvati1kan2t2ha1bharan2a.
+
+<p><b>Vag4rak4k4h.</b> s. Vajracchedika
+
+<p><b>Vag4ras.</b> s. Vajrasu1ci1 [pwj57]
+
+<p><b>Vag4ra1sanasa1dhanam.</b> s. Vajra1sanasa1dhanama1la1
+
+<p><b>Vaidjabh.</b> s. Vaidhyabha1s2ya
+
+<p><b>Vaidyabha1s2ya</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>Vaij.</b> s. Vaijayanti
+
+<p><b>Vaijayanti</b>
+<p>--...Ein Wörterbuch, Excerpte daraus von A. F. Stenzler. PW
+
+<p><b>Vais4es2ikha</b> The Vais4es2ikha Dars4an2a of Kan2ada. Ed. J.
+Tarkapan5ca1nana, Calcutta, 1860. 1861. [I.O. 2859] pw
+
+<p><b>Vaita1n.</b> s. Vaita1nasu1tra
+
+<p><b>Vaita1nasu1tra</b>
+<p>--...Ed. R. Garbe, Strassburg, 1878. [I.O. 2867] pw
+
+<p><b>Va1jasaneyisam2hita1</b> s. Yajurveda
+
+<p><b>Vajracchedika</b>
+<p>--...Ed. F. M. Müller, Oxford, 1881. [I.O. 2874] pw
+
+<p><b>Vajra1sanasa1dhanama1la1</b>
+<p>--...Handchrift in der Pariser Bibliothek. Nach Schiefer. PW
+
+<p><b>Vajrasu1ci1</b>
+<p>--...Ed. A. Weber, Berlin, 1860. [I.O. 2875] pw
+
+<p><b>Va1ju P.</b> s. Va1yu Pura1n2a
+
+<p><b>Va1lakh.</b> s. Va1lakhilya
+
+<p><b>Va1lakhilya</b>
+<p>--...Die zwischen R2gveda 8, 48, 49 eingeschobenen Lieder. PW, pw
+
+<p><b>Va1mana</b> s. Ka1ya1lam2ka1ra
+
+<p><b>Va1mana Pura1n2a</b>
+<p>--...Handschrift. pw
+
+<p><b>Vam2c11a Br.</b> s. Vam2s4a Bra1hman2a
+
+<p><b>Vam2s4a Bra1hman2a</b>
+<p>--...Ed. A. C. Burnell, Mangalore, 1873. [I.O. 2887] pw
+
+<p><b>Var.</b> = Variante
+
+<p><b>Vara1hamihira</b> s. Br2hajja1taka, Br2hatsam2hita1, Laghuja1taka,
+Yogara1tra.
+
+<p><b>Vara1ha Pura1n2a</b>
+<p>--...Handschrift. PW, pw
+
+<p><b>Vara1h. Br2h.</b> s. Br2hajja1taka
+
+<p><b>Vara1h. Br2hs.</b> s. Br2hatsam2hita1
+
+<p><b>Vara1h. Lagh.</b> s. Laghuja1taka
+
+<p><b>Vardhama1na Caritra</b>
+<p>--...Handschrift. pw [pwj58]
+
+<p><b>Va1r. P.</b> s. Va1ra1ha Pura1n2a
+
+<p><b>Va1rt.</b> s. Va1rtika1
+
+<p><b>Va1rtika1</b>
+<p>--...Von Ka1tya1yana zu Pa1n2ini. In Böhtlingks Ausgabe des Pa1n2ini. PW, pw
+
+<p><b>Va1s.</b> s. Va1santika1
+
+<p><b>Va1santika1</b>
+<p>--...Handschrift. pw
+
+<p><b>Va1sav.</b> s. Va1savadatta1
+<p>--...1. Ed. F. E. Hall, Calcutta, 1859. [I.O. 2908] pw
+<p>--...2. In: Z. d. d. m. G. VIII, Seite 530 ff. PW
+
+<p><b>Vasis2t2ha Dharmas4a1stra</b>
+<p>--...Ed. A. A. Führer, Poona, 1830. [I.O. 2910] pw
+
+<p><b>Va1stuv.</b> s. Va1stuvidya1
+
+<p><b>Va1stuvidya1</b>
+<p>--...Von Vis4vakarman. Handschrift. pw
+
+<p><b>Va1yu Pura1n2a</b> Nach Zitaten in anderen Werken. PW, pw
+
+<p><b>ved.</b> = vedisch
+
+<p><b>Veda1ntas.</b> s. Veda1ntasa1ra
+
+<p><b>Veda1ntasa1ra</b>
+<p>--...1. Ed. Calcutta, 1829. [Gild. 279] PW
+<p>--...2. Ed. J. R. Ballantyne, Allahabad, 1850. [I.O. 2937] PW
+
+<p><b>Veda P.</b> s. Veda Pura1n2a
+
+<p><b>Veda Pura1n2a</b>
+<p>--...Ohne weiteres im PW.
+
+<p><b>Ven2is.</b> s. Ven2isam2ha1ra
+
+<p><b>Ven2isam2ha1ra</b>
+<p>--...1. Nach Anführungen im S4KD. PW
+<p>--...2. Ed. J. Grill, Leipzig, 1871. [I.O. 2951] pw
+
+<p><b>Verh. d.k.s.G.d.Ww.</b> = Verhandlungen der königlich sächsischen
+Gesllschaft der Wissenschaften zu Leipzig.
+
+<p><b>Verz. d.B.H.</b> s. Berlin
+
+<p><b>Verz. d. Pet. H.</b> s. St. Petersburg
+
+<p><b>Vet.</b> s. Veta1lapan5cavim2s4atika
+
+<p><b>vata1lapan5cavim2s4atika</b>
+<p>--...1. In: Anthologia sanscritica. PW, pw
+<p>--...2. Ed. H. Uhle, Leipzig, 1881. [I.O. 2969] pw
+
+<p><b>Vic11v.</b> s. Vis4vamitras Kampf
+
+<p><b>Vic11vak.</b> s. Vic11vakos4a [pwj59]
+
+<p><b>Vid.</b> s. Geschichte des Vidu1s4aka
+
+<p><b>Vidagdhamukham.</b> s. Vidagdhamukhaman2d2ana
+
+<p><b>Vidagdhamukhaman2d2ana</b>
+<p>--...Nach Anführungen im S4KD. PW
+
+<p><b>Viddh.</b> s. Viddhas4alabhan5jikha1khya1na1nat2ika1
+
+<p><b>Viddhas4a1labhan5jikha1khya1na1nat2ika1</b>
+<p>--...In der Zeitschrift Pratnakmranan2d2ini1. pw
+
+<p><b>Vikr.</b> s. Vikramorvas4i1
+
+<p><b>Vikraman3kak4.</b> s. Vikraman3kacarita
+
+<p><b>Vikraman3kacarita</b>
+<p>--...Ed. G. Bühler, Bombay, 1875. [I.O. 1875] pw
+
+<p><b>Vikramorvas4i1</b>
+<p>--...Ed. F. Bollensen, Leipzig, St. Petersburg, 1846. [I.O. 2991] PW, pw
+<p>--...2. Nach dravidischen Handschriften, herausgegeben von R. Pischel in:
+Monatsbericht der königlich preussischen Akademie der Wissenschaften zu Berlin,
+1875, Seite 609 ff. pw
+
+<p><b>Vikr. drav.</b> s. Vikramorvas4i1
+
+<p><b>Vi1ram.</b> s. Vi1ramitrodaya
+
+<p><b>Vi1ramitrodaya</b>
+<p>--...Ed. Calcutta, 1815. [I.O. 3005] PW, pw
+
+<p><b>Vis2n2u Su1tra</b>
+<p>--...Ed. H. H. Wilson, London, 1840. [I.O. 3021] PW, pw
+<p>--... Unbekannte Bombayer Ausgabe. pw
+
+<p><b>Vis2n2u Su1tra</b>
+<p>--...Ed. J. Jolly, Oxford, 1880. [I.O. 3033] pw
+
+<p><b>Viva1dacinta1man2i1</b>
+<p>--...1. Ed. R. Vidya1va1gi1s4a, Calcutta, 1837. [Gild. 351] PW
+<p>--...2. Ed. R. Vidya1va1gi1s4a, Calcutta, 1894. PW
+
+<p><b>Viva1dak4.</b> s. Viva1dacinta1man2i1
+
+<p><b>Viva1da1rn2.</b> s. Viva1da1rn2avasetu
+
+<p><b>Vivada1rn2avasetu</b>
+<p>--...Nach Anführungen im S4KD. PW
+
+<p><b>Vivekav.</b> s. Vivekavila1sa
+
+<p><b>Vivekavila1sa</b>
+<p>--...In der Zeitschrift Pratnakamranandini1. pw
+
+<p><b>Vis4vakos4a</b>
+<p>--...Ohne weiteres im pw.
+
+<p><b>Vjut.</b> s. Vyutpatti [pwj60]
+
+<p><b>V.L.</b> = Varia Lectio
+
+<p><b>Vop.</b> s. Vopadeva
+
+<p><b>Vopadeva</b> s. Mugdhabodha
+
+<p><b>VP.</b> s. Vis2n2u Pura1n2a
+
+<p><b>Vr2s2abha1nuja</b>
+<p>--...Im 3. und 4. Buch des Pandit. pw
+
+<p><b>Vr2shabh.</b> s. Vr2s2abha1nuja
+
+<p><b>VS.</b> Pra1t2r2pra1tis4a1khya zur Va1jasaneyisam2hita1
+
+<p><b>Vyutpatti</b>
+<p>--...Ein Sanskrit-tibetisch-mongolisches Wörterbuch. Nach Schiefner. PW St.
+Petersburg, 1859. PW, pw
+
+<p><b>West.</b> s. Westergaard
+
+<p><b>Westergaard</b> s. Radices
+
+<p><b>Willmot, E.</b> A Catalogue of Sanscrit Manuscripts existing in the
+Central Provinces. pw
+
+<p><b>Wils.</b> s. Wilson
+
+<p><b>Wilson, H.H.</b> 1. A. Dictionary in Sanscrit and English, Calcutta, 1832.
+pw 2. s. Select Specimens
+
+<p><b>Windischmann, F.H.H.</b> Sancara sive de Theologumenis Vedanticorum Ed. F.
+H. H. Windischmann, Bonn, 1832. [I.O. 262] PW, pw
+
+<p><b>Wind. Sanc.</b> s. Windischmann
+
+<p><b>Wise</b> s. Commentary
+
+<p><b>Yajn5adattavadha</b>
+<p>--...Ed. A. L. Deslongchamps, Paris, 1829. PW
+
+<p><b>Ya1jn5yavalkyas Gesetzbuch</b>
+<p>--...Ed. A. F. Stenzler, Berlin, 1849. [I.O. 3094] PW, pw
+
+<p><b>Yajurveda</b>
+<p>--...Ed. A. Weber, london, Berlin, 1852-59. [I.O. 3085] PW, pw Mit: S4atapatha
+Bra1hman2a, den Kommentatoren Sa1yan2a, Harisva1min, Dvivedagan3ga, Mahi1dhara,
+dem S4rautasu1tra des Ka1tya1yana, den Kommentatoren Karka und Ya1jn5ikadeva.
+
+<p><b>Yogara1tra</b> s. Indische Studien
+
+<p><b>Yogas4a1stra</b>
+<p>--...Von Hemacandra. In: Z. d. d. m. G. 28. pw
+
+<p><b>Yogas4ikha Upanis2ad</b> s. Atharvan2a Upanis2ads
+
+<p><b>Yogasu1tra</b>
+<p>--...Von Patan5jali. Ed. J. R. Ballantyne, Allahabad, 1852. I.O. 3137] PW, pw
+[pwj61]
+
+<p><b>Yogatattva</b> s. Indisch Studien
+
+<p><b>Yogatattva Upanis2ad</b> s. Atharvan2a Upanis2ads
+
+<p><b>Yuktikalpataru</b>
+<p>--...Ohne weiteres im PW.
+
+<p><b>Zach. Beitr.</b> s. Beiträge <i>Z.d.d.m.G.</i> = Zeitschrift der
+deutschen morgenländischen Gesellschaft
+
+<p><b>Z.f.d.K.d.M.</b> = Zeitschrift für die Kunde des Morgenlandes
+
+<p><b>Z.f.d.W.d.Spr.</b> = Zeitschrift für die Wissenschaft der Sprache.
+Herausgegeben von A. Höfer.
+
+<p><b>Z. f. vgl. Spr.</b> = Zeitschrift für vergleichende Sprachforschung auf
+dem Gebiete des Deutschen, Griechichen und Lateinischen, herausgegeben von Th.
+Aufrecht und Adalbert Kuhn. Berlin.
+
+<p><b>Zur Geschichte</b>
+<p>--...der griechichen und indoskythischen Könige in Baktrien, Kabul, und Indien
+durch Entzifferung der altkabulischen Legenden auf ihren Münzen von Chr. Lassen,
+Bonn, 1838.
+
+<p><b>Zur Literatur und Geschichte des Veda (Z. L. u. G. d. W. )</b> Drei
+Abhandlungen von R. Roth, Stuttgart, 1846.
+
+<p><b>Zwölf Hymnen</b>
+<p>--...des R2gveda. Ed. E. Windisch. Seite 169 ff.
+
+
+


### PR DESCRIPTION
Acts on the finding from [PR #125](https://github.com/sanskrit-lexicon/PWK/pull/125): the Jachertz edition/shelfmark layer was digitized but idle. This makes it machine-usable, and corrects the `/blob/master/` → `/blob/main/` links #125 introduced (this repo's default branch is `main`).

Nothing is written back to canonical `pwbib` files — all three outputs are new, reviewable artifacts regenerated by [`jachertz_parse.py`](https://github.com/sanskrit-lexicon/PWK/blob/main/pw_ls/pwbib/jachertz/jachertz_parse.py):

1. **cp1252 → UTF-8** — [`orig/pw-jachertz-utf8.txt`](https://github.com/sanskrit-lexicon/PWK/blob/main/pw_ls/pwbib/jachertz/orig/pw-jachertz-utf8.txt) (strict decode, 0 replacement chars, BOM-free; AS-numeric Sanskrit left intact).
2. **Structured parse** — [`jachertz_bib.tsv`](https://github.com/sanskrit-lexicon/PWK/blob/main/pw_ls/pwbib/jachertz/jachertz_bib.tsv): **1,169 entries** (503 works + 626 `s.` cross-refs + 40 `=` expansions), **522 editions**, **155 India-Office + 32 Gildemeister shelfmarks**, PW/pw usage tags. First time the edition/shelfmark layer is queryable.
3. **Backfill candidates** — [`jachertz_backfill_candidates.tsv`](https://github.com/sanskrit-lexicon/PWK/blob/main/pw_ls/pwbib/jachertz/jachertz_backfill_candidates.tsv): a conservative match (exact / `s.`-xref / unique-prefix on a digit-stripped key — the two data sets use different digit schemes) resolves **37 of the 287** unresolved `mergebibnew` stubs (e.g. `PANINI` → Pāṇini, Ed. Böhtlingk Bonn 1840; `KATANTRA` → Kātantra; `VEDANTASARA` → Vedāntasāra, 2 eds.). **For human review, not applied** — `exact`/`xref` solid, `prefix` least certain.

**Remaining (resumable):** a full AS-scheme normalizer (Jachertz `a1`/`s4`/`n2` ↔ pwbib `A7`/`C2`/`S2`) to lift recall past this high-precision floor; and wiring the prepared bib-hyperlinks into the PWK display (`disp.php` ↔ sqlite), never deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
