### PR TITLE
docs(README): refresh stale issue/milestone counts + org MD hygiene (H548)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,33 +1,34 @@
+# PWK
 
-PWK
-===
+_Created: 08-03-2020 · Last updated: 11-07-2026_
 
 Böhtlingk, Otto; *Sanskrit-Wörterbuch in kürzerer Fassung*, 7 Bände. St. Petersburg, 1879–1889.
 
 This repository holds corrections, enhancements, and tooling for the [Cologne digitization](http://www.sanskrit-lexicon.uni-koeln.de/) of the PWK dictionary. The canonical source data (`pw.txt` in SLP1 encoding) lives in [csl-orig](https://github.com/sanskrit-lexicon/csl-orig); the build system is in [csl-pywork](https://github.com/sanskrit-lexicon/csl-pywork). Issues and corrections are tracked at the [PWK GitHub issue tracker](https://github.com/sanskrit-lexicon/PWK/issues).
 
+Corrections to the Cologne source text are never committed directly to `csl-orig`; they are prepared as `updateByLine.py` change files and delivered in batched pull requests per the canonical [correction workflow](https://github.com/sanskrit-lexicon/csl-corrections/blob/main/docs/correction-workflow.md).
+
 ## Contents
 
 | Directory | Description |
 |-----------|-------------|
-| `pw_ls/` | Bibliography and literary-source analysis: `pwbib*.txt` tables, `crefmatch.py`, fuzzy-match pipelines |
-| `pwkissues/` | Per-issue correction workflows and documentation (`issueNNN/` pattern) |
-| `abbrev/` | General abbreviation (`<ab>`) markup pipeline |
-| `convertwork/` | SLP1 ↔ HK transcoding utilities |
-| `verbs01/` | PW verb identification and correlation with MW verbs |
-| `pwkvn/` | PWKVN (variant supplement) data — `step0/`, `step1/`, `install/` |
-| `vn-sch/` | VN vs. Schmidt comparison and correction work |
-| `pw_iast/` | IAST transcoding of `pw.txt` |
-| `prefaces/` | Front-matter OCR (title page, *Vorwort*, *Verzeichniss der citirten Werke*) with English + Russian translations — see below |
+| [`pw_ls/`](https://github.com/sanskrit-lexicon/PWK/tree/main/pw_ls) | Bibliography and literary-source analysis: `pwbib*.txt` tables, `crefmatch.py`, fuzzy-match pipelines |
+| [`pwkissues/`](https://github.com/sanskrit-lexicon/PWK/tree/main/pwkissues) | Per-issue correction workflows and documentation (`issueNNN/` pattern) |
+| [`abbrev/`](https://github.com/sanskrit-lexicon/PWK/tree/main/abbrev) | General abbreviation (`<ab>`) markup pipeline |
+| [`convertwork/`](https://github.com/sanskrit-lexicon/PWK/tree/main/convertwork) | SLP1 ↔ HK transcoding utilities |
+| [`verbs01/`](https://github.com/sanskrit-lexicon/PWK/tree/main/verbs01) | PW verb identification and correlation with MW verbs |
+| [`pwkvn/`](https://github.com/sanskrit-lexicon/PWK/tree/main/pwkvn) | PWKVN (variant supplement) data — `step0/`, `step1/`, `install/` |
+| [`vn-sch/`](https://github.com/sanskrit-lexicon/PWK/tree/main/vn-sch) | VN vs. Schmidt comparison and correction work |
+| [`pw_iast/`](https://github.com/sanskrit-lexicon/PWK/tree/main/pw_iast) | IAST transcoding of `pw.txt` |
+| [`prefaces/`](https://github.com/sanskrit-lexicon/PWK/tree/main/prefaces) | Front-matter OCR (title page, *Vorwort*, *Verzeichniss der citirten Werke*) with English + Russian translations — see below |
 
 ## Front matter (`prefaces/`)
 
-Faithful OCR of the five front-matter scan pages of vol. 1 (*Erster Theil — Die Vocale*, St. Petersburg 1879), each in the German source plus English and Russian translations, with consolidated single-file editions and a [`prefaces/README.md`](prefaces/README.md) index. Source: the Cologne [csldoc preface scans](https://sanskrit-lexicon.uni-koeln.de/scans/csldev/csldoc/build/dictionaries/prefaces/pwpref.html). The *Verzeichniss* is a 304-entry bibliographic key list (100 + 106 + 98). Böhtlingk's romanization is preserved as printed (`â î û` = long vowels, `ç` = ś, `sh` = ṣ, `j` = y, `ḱ` = c, `ǵ` = j); Devanāgarī and Vikrama-Saṃvat dates (e.g. *Benares 1921*) are kept verbatim. The Foreword sign-off (*Jena, den 1sten Mai 1879. — O. Böhtlingk.*) is preserved; digitizer header/footer stamps are omitted.
+Faithful OCR of the five front-matter scan pages of vol. 1 (*Erster Theil — Die Vocale*, St. Petersburg 1879), each in the German source plus English and Russian translations, with consolidated single-file editions and a [`prefaces/README.md`](https://github.com/sanskrit-lexicon/PWK/blob/main/prefaces/README.md) index. Source: the Cologne [csldoc preface scans](https://sanskrit-lexicon.uni-koeln.de/scans/csldev/csldoc/build/dictionaries/prefaces/pwpref.html). The *Verzeichniss* is a 304-entry bibliographic key list (100 + 106 + 98). Böhtlingk's romanization is preserved as printed (`â î û` = long vowels, `ç` = ś, `sh` = ṣ, `j` = y, `ḱ` = c, `ǵ` = j); Devanāgarī and Vikrama-Saṃvat dates (e.g. *Benares 1921*) are kept verbatim. The Foreword sign-off (*Jena, den 1sten Mai 1879. — O. Böhtlingk.*) is preserved; digitizer header/footer stamps are omitted.
 
-<details>
-<summary><strong>OCR run notes (2026-06-17)</strong> — cost, timing, and technical lessons</summary>
+### OCR run notes (2026-06-17)
 
-Produced by the `/cologne-preface-ocr` skill (vision OCR + translation subagents). Process retrospective, not part of the deliverable.
+> Process retrospective, not part of the deliverable. Produced by the `/cologne-preface-ocr` skill (vision OCR + translation subagents).
 
 **Cost.** Subagents (exact, from harness telemetry): 6 agents, ≈413,100 output tokens, 89 tool calls — OCR page 4 (92.6k / 40 calls / 356 s), OCR page 5 (66.3k / 194 s), RU 3–5 (77.3k / 199 s), EN 3–5 (76.6k / 184 s), RU 1–2 (50.7k / 64 s), EN 1–2 (49.6k / 44 s). Main thread (estimate, dominated by ~30 native-resolution image-crop reads): ≈80–120k tokens. **Total ≈500–550k tokens.**
 
@@ -41,10 +42,8 @@ Produced by the `/cologne-preface-ocr` skill (vision OCR + translation subagents
 4. **Subagents silently drop "non-list" content.** The page-5 agent omitted the sign-off as "not an entry"; it sits below the columns on the last list page. Always re-add place/date/signature.
 5. **Fidelity vs. correctness, resolved by parallel evidence.** *"Benares 1921"* looked wrong but is a real Saṃvat date (kept verbatim); *"Mahâbhâsuja"* looked real but was a scan artifact of *"Mahâbhâshja"* (fixed, confirmed by the adjacent *Mahâbh. (K.)* entry). The discriminator was always another occurrence on the same page.
 6. **Encoding.** All 20 `.md` files written UTF-8 **no BOM**; git's LF→CRLF warning on Windows is cosmetic (committed blobs are LF).
-7. **Push raced a moved remote** — resolved with an add-only `fetch` + `rebase origin/master` + `push` (conflict-free, all files new).
+7. **Push raced a moved remote** — resolved with an add-only `fetch` + `rebase` + `push` (conflict-free, all files new).
 8. **Repo-name trap:** dict code `pw` lives in repo **PWK**, not "PW".
-
-</details>
 
 ## Timeline
 
@@ -61,45 +60,45 @@ Produced by the `/cologne-preface-ocr` skill (vision OCR + translation subagents
 | Aug 2023 | Abbreviation markup continued (issue88 workflow) |
 | 2024 | Bot tags (#111); BHĀGAVATAPURĀṆA LS markup (#109, #110); display revisions (#97) |
 | Jun–Oct 2025 | MBH Bombay links (#84); Ramayana Gorresio/Schlegel link splitting (#83fix, #83fixa) |
-| Jun 2026 | Front-matter OCR + EN/RU translations of vol. 1 prefaces (`prefaces/`) |
+| Jun–Jul 2026 | Front-matter OCR + EN/RU translations of vol. 1 prefaces (`prefaces/`); Jachertz 1983 bibliography backfill for `pwbib_new` stubs (#129) |
 
 ## Projects & Milestones
 
-Work is organised into four GitHub Projects (org-level kanban boards), each mirroring a milestone:
+Work is organised into four GitHub Projects (org-level kanban boards), each mirroring a milestone. Open/closed counts below are live as of 11-07-2026.
 
 | Project | Milestone | Open | Closed | Scope |
 |---|---|---|---|---|
-| [**Dictionary to Book**](https://github.com/orgs/sanskrit-lexicon/projects/1) | [milestone](https://github.com/sanskrit-lexicon/PWK/milestone/1) | 4 | 3 | Link targets and link splitting |
-| [**Digitization Quality**](https://github.com/orgs/sanskrit-lexicon/projects/2) | [milestone](https://github.com/sanskrit-lexicon/PWK/milestone/2) | 5 | 12 | Scan quality, encoding, bug fixes, text corrections |
-| [**Structured Data**](https://github.com/orgs/sanskrit-lexicon/projects/3) | [milestone](https://github.com/sanskrit-lexicon/PWK/milestone/3) | 20 | 45 | Markup normalisation, bibliography cross-references, editorial questions |
-| [**Major Enhancements**](https://github.com/orgs/sanskrit-lexicon/projects/4) | [milestone](https://github.com/sanskrit-lexicon/PWK/milestone/4) | 11 | 11 | Display upgrades, new data, VN supplement, verb markup |
+| [**Dictionary to Book**](https://github.com/orgs/sanskrit-lexicon/projects/1) | [milestone 1](https://github.com/sanskrit-lexicon/PWK/milestone/1) | 4 | 3 | Link targets and link splitting |
+| [**Digitization Quality**](https://github.com/orgs/sanskrit-lexicon/projects/2) | [milestone 2](https://github.com/sanskrit-lexicon/PWK/milestone/2) | 2 | 15 | Scan quality, encoding, bug fixes, text corrections |
+| [**Structured Data**](https://github.com/orgs/sanskrit-lexicon/projects/3) | [milestone 3](https://github.com/sanskrit-lexicon/PWK/milestone/3) | 20 | 47 | Markup normalisation, bibliography cross-references, editorial questions |
+| [**Major Enhancements**](https://github.com/orgs/sanskrit-lexicon/projects/4) | [milestone 4](https://github.com/sanskrit-lexicon/PWK/milestone/4) | 12 | 11 | Display upgrades, new data, VN supplement, verb markup |
 
 ```mermaid
 pie title Closed issues by milestone
-    "Structured Data" : 45
+    "Structured Data" : 47
+    "Digitization Quality" : 15
     "Major Enhancements" : 11
-    "Digitization Quality" : 12
     "Dictionary to Book" : 3
 ```
 
 ```mermaid
 pie title Open issues by milestone
     "Structured Data" : 20
-    "Major Enhancements" : 11
-    "Digitization Quality" : 5
+    "Major Enhancements" : 12
     "Dictionary to Book" : 4
+    "Digitization Quality" : 2
 ```
 
 ## Issue Typology
 
-Issues track two broad concerns: **enriching the XML markup** (bibliography, link targets) and **improving the digitization** (encoding, scan quality, text corrections).
+Issues track two broad concerns: **enriching the XML markup** (bibliography, link targets) and **improving the digitization** (encoding, scan quality, text corrections). Type-label counts below are live as of 11-07-2026 (38 open, 76 closed; 114 total).
 
 ```mermaid
 pie title Issues by type label
-    "markup" : 56
-    "content-enhancement" : 22
+    "markup" : 57
+    "content-enhancement" : 23
+    "question" : 10
     "text-correction" : 9
-    "question" : 9
     "link-target" : 7
     "bug" : 4
     "scan-quality" : 3
@@ -110,13 +109,13 @@ pie title Issues by type label
 
 | Type | Count | Description | Examples |
 |---|---|---|---|
-| **Markup** | 41 | Bibliography cross-reference corrections (`bibminuscref`/`crefminusbib` series); `<ls>`, `<ab>`, `<is>` tag normalisation | Correction series [#18](https://github.com/sanskrit-lexicon/PWK/issues/18)–[#59](https://github.com/sanskrit-lexicon/PWK/issues/59), bot tags [#111](https://github.com/sanskrit-lexicon/PWK/issues/111), `<is>` tag [#95](https://github.com/sanskrit-lexicon/PWK/issues/95) |
+| **Markup** | 42 | Bibliography cross-reference corrections (`bibminuscref`/`crefminusbib` series); `<ls>`, `<ab>`, `<is>` tag normalisation | Correction series [#18](https://github.com/sanskrit-lexicon/PWK/issues/18)–[#59](https://github.com/sanskrit-lexicon/PWK/issues/59), bot tags [#111](https://github.com/sanskrit-lexicon/PWK/issues/111), `<is>` tag [#95](https://github.com/sanskrit-lexicon/PWK/issues/95) |
 | **Content enhancement** | 11 | Display upgrades, VN supplement, verb pipeline, new dictionary data | PWKVN supplement [#86](https://github.com/sanskrit-lexicon/PWK/issues/86), verbs01 [#68](https://github.com/sanskrit-lexicon/PWK/issues/68), alternate headwords [#106](https://github.com/sanskrit-lexicon/PWK/issues/106) |
-| **Text corrections** | 6 | Corrections to German definitions, Sanskrit headwords, PWKVN revisions | AB revisions [#102](https://github.com/sanskrit-lexicon/PWK/issues/102), [#103](https://github.com/sanskrit-lexicon/PWK/issues/103), LS corrections [#79](https://github.com/sanskrit-lexicon/PWK/issues/79) |
+| **Text corrections** | 8 | Corrections to German definitions, Sanskrit headwords, PWKVN revisions | AB revisions [#102](https://github.com/sanskrit-lexicon/PWK/issues/102), [#103](https://github.com/sanskrit-lexicon/PWK/issues/103), LS corrections [#79](https://github.com/sanskrit-lexicon/PWK/issues/79) |
 | **Link targets** | 3 | Clickable links from `<ls>` abbreviations to scanned PDF pages | Gorresio Ramayana [#90](https://github.com/sanskrit-lexicon/PWK/issues/90), BHĀGAVATAPURĀṆA PWKVN [#110](https://github.com/sanskrit-lexicon/PWK/issues/110) |
 | **Scan quality** | 3 | Missing or poor-quality scans replaced | Better CDSL images [#112](https://github.com/sanskrit-lexicon/PWK/issues/112), pw scans for VN [#107](https://github.com/sanskrit-lexicon/PWK/issues/107) |
-| **Bug fixes** | 2 | Broken display, `<pc>` page-column errors | `<pc>` at volume boundary [#94](https://github.com/sanskrit-lexicon/PWK/issues/94), web path [#7](https://github.com/sanskrit-lexicon/PWK/issues/7) |
-| **Questions resolved** | 4 | Editorial and scholarly questions researched and answered | Abbreviation in German [#49](https://github.com/sanskrit-lexicon/PWK/issues/49), submission format [#42](https://github.com/sanskrit-lexicon/PWK/issues/42) |
+| **Bug fixes** | 3 | Broken display, `<pc>` page-column errors | `<pc>` at volume boundary [#94](https://github.com/sanskrit-lexicon/PWK/issues/94), web path [#7](https://github.com/sanskrit-lexicon/PWK/issues/7) |
+| **Questions resolved** | 5 | Editorial and scholarly questions researched and answered | Abbreviation in German [#49](https://github.com/sanskrit-lexicon/PWK/issues/49), submission format [#42](https://github.com/sanskrit-lexicon/PWK/issues/42) |
 | **Encoding** | 1 | SLP1/IAST transcoding | SLP1 conversion [#9](https://github.com/sanskrit-lexicon/PWK/issues/9) |
 
 #### Open (work ahead)
@@ -124,11 +123,11 @@ pie title Issues by type label
 | Type | Count | Description | Examples |
 |---|---|---|---|
 | **Markup** | 15 | Bibliography gaps, missing `<ls>` markup, bibliography title improvements | Missing markup [#67](https://github.com/sanskrit-lexicon/PWK/issues/67), LS sequences [#80](https://github.com/sanskrit-lexicon/PWK/issues/80), pwbib titles [#65](https://github.com/sanskrit-lexicon/PWK/issues/65) |
-| **Content enhancement** | 11 | Display revisions, PW/PWG LS display, VN7 Schmidt | Display revisions [#97](https://github.com/sanskrit-lexicon/PWK/issues/97), LS display [#96](https://github.com/sanskrit-lexicon/PWK/issues/96), VN7 Schmidt [#75](https://github.com/sanskrit-lexicon/PWK/issues/75) |
+| **Content enhancement** | 12 | Display revisions, PW/PWG LS display, VN7 Schmidt | Display revisions [#97](https://github.com/sanskrit-lexicon/PWK/issues/97), LS display [#96](https://github.com/sanskrit-lexicon/PWK/issues/96), VN7 Schmidt [#75](https://github.com/sanskrit-lexicon/PWK/issues/75) |
 | **Link targets** | 4 | Literary sources still needing index and links | BHĀGAVATAPURĀṆA PW [#109](https://github.com/sanskrit-lexicon/PWK/issues/109), MBH Bombay [#84](https://github.com/sanskrit-lexicon/PWK/issues/84), Ramayana [#83](https://github.com/sanskrit-lexicon/PWK/issues/83) |
-| **Text corrections** | 3 | Ongoing correction batches | Thomas corrections [#100](https://github.com/sanskrit-lexicon/PWK/issues/100), PWKVN3 vs Schmidt [#77](https://github.com/sanskrit-lexicon/PWK/issues/77), VN page typing [#76](https://github.com/sanskrit-lexicon/PWK/issues/76) |
 | **Questions** | 5 | Scholarly questions requiring research | ṚV citations [#98](https://github.com/sanskrit-lexicon/PWK/issues/98), s.u. markup [#66](https://github.com/sanskrit-lexicon/PWK/issues/66), further work [#108](https://github.com/sanskrit-lexicon/PWK/issues/108) |
-| **Bug fixes** | 2 | Known display and formatting errors | Abbreviations bracket [#12](https://github.com/sanskrit-lexicon/PWK/issues/12), correction submission [#6](https://github.com/sanskrit-lexicon/PWK/issues/6) |
+| **Text corrections** | 1 | Ongoing correction batches | Thomas corrections [#100](https://github.com/sanskrit-lexicon/PWK/issues/100) |
+| **Bug fixes** | 1 | Known display and formatting errors | Correction submission [#6](https://github.com/sanskrit-lexicon/PWK/issues/6) |
 
 ## Labels
 
@@ -164,3 +163,5 @@ Every issue carries one **type** label and one **severity** label.
 - **Thomas Malten** ([@thomasincambodia](https://github.com/thomasincambodia)) — corrections and headword classifications
 - **Mārcis Gasūns** ([@gasyoun](https://github.com/gasyoun)) — initial commit and early data work
 - **Andhrabharati** (Nagabhushana Rao) — AB version analysis; LS correction data
+
+_Dr. Mārcis Gasūns_


### PR DESCRIPTION
Part of **H548** (README audit + refresh across Cologne dictionary repos).

## What changed
Rewrote [`README.md`](https://github.com/sanskrit-lexicon/PWK/blob/readme-refresh-h548/README.md) so every status claim is currently true as of 11-07-2026, verified against the live GitHub API.

### Corrected stale counts (live vs. old)
| Metric | Was | Now |
|---|---|---|
| Digitization Quality milestone | 5 open / 12 closed | **2 open / 15 closed** |
| Structured Data milestone | 20 / 45 | 20 / **47** |
| Major Enhancements milestone | **11** open / 11 | **12** open / 11 |
| `markup` type label | 56 | **57** |
| `content-enhancement` type label | 22 | **23** |
| `question` type label | 9 | **10** |

Totals reconciled: 38 open, 76 closed (114 total); Solved/Open breakdown tables and both milestone mermaid pies recomputed to match.

### Org Markdown-convention fixes
- Added dated header `_Created: 08-03-2020 · Last updated: 11-07-2026_` (creation date from `git log --follow`) and the `_Dr. Mārcis Gasūns_` byline.
- **Removed raw HTML** (`<details>`/`<summary>`/`<strong>`) that violated the no-HTML-in-`.md` rule; OCR run notes retained as a plain subsection with a blockquote intro.
- Converted Contents-table paths and the relative `prefaces/README.md` link to full `github.com` tree/blob URLs.
- Linked the canonical [correction-workflow doc](https://github.com/sanskrit-lexicon/csl-corrections/blob/main/docs/correction-workflow.md) instead of implying direct `csl-orig` edits.
- Timeline: extended the Jun 2026 row with the Jachertz 1983 bibliography backfill (#129).

## Notes
- The tracked file is lowercase `readme.md`; on Windows' case-insensitive FS the on-disk `README.md` maps to it, so the diff shows `readme.md`.
- No main/master divergence: default branch is `main`; there is no `master`. The `jachertz-live-baseline` feature branch is 3 ahead / 1 behind main but is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)